### PR TITLE
Assign XPN roles at the folder level in the per-environment foundation example

### DIFF
--- a/foundations/environments/README.md
+++ b/foundations/environments/README.md
@@ -37,7 +37,8 @@ If no shared services are needed, the shared service project module can of cours
 | environments | Environment short names. | list(string) | n/a | yes |
 | gcs\_location | GCS bucket location. | string | `"EU"` | no |
 | generate\_service\_account\_keys | Generate and store service account keys in the state file. | string | `"false"` | no |
-| grant\_xpn\_roles | Grant roles needed for Shared VPC creation to service accounts. | string | `"true"` | no |
+| grant\_xpn\_folder\_roles | Grant roles needed for Shared VPC creation to service accounts at the environment folder level. | string | `"true"` | no |
+| grant\_xpn\_org\_roles | Grant roles needed for Shared VPC creation to service accounts at the organization level. | string | `"false"` | no |
 | organization\_id | Organization id. | string | n/a | yes |
 | prefix | Prefix used for resources that need unique names. | string | n/a | yes |
 | project\_services | Service APIs enabled by default in new projects. | list | `<list>` | no |

--- a/foundations/environments/main.tf
+++ b/foundations/environments/main.tf
@@ -41,7 +41,7 @@ module "service-accounts-tf-environments" {
   prefix             = var.prefix
   names              = var.environments
   grant_billing_role = true
-  grant_xpn_roles    = var.grant_xpn_roles
+  grant_xpn_roles    = var.grant_xpn_org_roles
   generate_keys      = var.generate_service_account_keys
 }
 
@@ -76,8 +76,6 @@ module "gcs-tf-environments" {
 #                              Top-level folders                              #
 ###############################################################################
 
-# TODO(ludomagno): move XPN admin role here after checking it now works on folders
-
 module "folders-top-level" {
   source            = "terraform-google-modules/folders/google"
   version           = "2.0.0"
@@ -85,12 +83,15 @@ module "folders-top-level" {
   names             = var.environments
   set_roles         = true
   per_folder_admins = module.service-accounts-tf-environments.iam_emails_list
-  folder_admin_roles = [
-    "roles/resourcemanager.folderViewer",
-    "roles/resourcemanager.projectCreator",
-    "roles/owner",
-    "roles/compute.networkAdmin",
-  ]
+  folder_admin_roles = compact(
+    [
+      "roles/compute.networkAdmin",
+      "roles/owner",
+      "roles/resourcemanager.folderViewer",
+      "roles/resourcemanager.projectCreator",
+      var.grant_xpn_folder_roles ? "roles/compute.xpnAdmin" : ""
+    ]
+  )
 }
 
 ###############################################################################

--- a/foundations/environments/variables.tf
+++ b/foundations/environments/variables.tf
@@ -37,11 +37,15 @@ variable "gcs_location" {
   default     = "EU"
 }
 
-variable "grant_xpn_roles" {
-  description = "Grant roles needed for Shared VPC creation to service accounts."
-  default     = true
+variable "grant_xpn_org_roles" {
+  description = "Grant roles needed for Shared VPC creation to service accounts at the organization level."
+  default     = false
 }
 
+variable "grant_xpn_folder_roles" {
+  description = "Grant roles needed for Shared VPC creation to service accounts at the environment folder level."
+  default     = true
+}
 
 variable "organization_id" {
   description = "Organization id."


### PR DESCRIPTION
This moves XPN role assignment for environment service accounts from the org to the folder, enforcing proper separation at the environment level.