### PR TITLE
subnets with the same name in different regions

### DIFF
--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -20,6 +20,12 @@ variable "auto_create_subnetworks" {
   default     = false
 }
 
+variable "delete_default_routes_on_create" {
+  description = "Set to true to delete the default routes at creation time."
+  type        = bool
+  default     = false
+}
+
 variable "description" {
   description = "An optional description of this resource (triggers recreation on change)."
   type        = string
@@ -27,19 +33,19 @@ variable "description" {
 }
 
 variable "iam_roles" {
-  description = "List of IAM roles keyed by subnet."
+  description = "List of IAM roles keyed by subnet 'region/name'."
   type        = map(list(string))
   default     = null
 }
 
 variable "iam_members" {
-  description = "List of IAM members keyed by subnet and role."
+  description = "List of IAM members keyed by subnet 'region/name' and role."
   type        = map(map(list(string)))
   default     = null
 }
 
 variable "log_configs" {
-  description = "Map of per-subnet optional configurations for flow logs when enabled."
+  description = "Map keyed by subnet 'region/name' of optional configurations for flow logs when enabled."
   type        = map(map(string))
   default     = null
 }
@@ -109,30 +115,31 @@ variable "shared_vpc_service_projects" {
 }
 
 variable "subnets" {
-  description = "Subnets being created. If name is set to null, a default will be used combining network name and this map key."
-  type = map(object({
+  description = "The list of subnets being created"
+  type = list(object({
+    name               = string
     ip_cidr_range      = string
     name               = string
     region             = string
     secondary_ip_range = map(string)
   }))
-  default = null
+  default = []
 }
 
 variable "subnet_descriptions" {
-  description = "Optional map of subnet descriptions, keyed by subnet name."
+  description = "Optional map of subnet descriptions, keyed by subnet 'region/name'."
   type        = map(string)
   default     = {}
 }
 
 variable "subnet_flow_logs" {
-  description = "Optional map of boolean to control flow logs (default is disabled), keyed by subnet name."
+  description = "Optional map of boolean to control flow logs (default is disabled), keyed by subnet 'region/name'."
   type        = map(bool)
   default     = {}
 }
 
 variable "subnet_private_access" {
-  description = "Optional map of boolean to control private Google access (default is enabled), keyed by subnet name."
+  description = "Optional map of boolean to control private Google access (default is enabled), keyed by subnet 'region/name'."
   type        = map(bool)
   default     = {}
 }

--- a/tests/modules/net_vpc/fixture/variables.tf
+++ b/tests/modules/net_vpc/fixture/variables.tf
@@ -97,13 +97,14 @@ variable "shared_vpc_service_projects" {
 
 variable "subnets" {
   description = "The list of subnets being created"
-  type = map(object({
+  type = list(object({
+    name               = string
     ip_cidr_range      = string
     name               = string
     region             = string
     secondary_ip_range = map(string)
   }))
-  default = null
+  default = []
 }
 
 variable "subnet_descriptions" {

--- a/tests/modules/net_vpc/test_plan_subnets.py
+++ b/tests/modules/net_vpc/test_plan_subnets.py
@@ -19,14 +19,14 @@ import pytest
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
 _VAR_SUBNETS = (
-    '{ '
-    'a={region = "europe-west1", ip_cidr_range = "10.0.0.0/24",'
-    '   name=null, secondary_ip_range=null},'
-    'b={region = "europe-west1", ip_cidr_range = "10.0.1.0/24",'
-    '   name=null, secondary_ip_range=null},'
-    'c={region = "europe-west1", ip_cidr_range = "10.0.2.0/24",'
-    '   name="c", secondary_ip_range={a="192.168.0.0/24", b="192.168.1.0/24"}},'
-    '}'
+    '[ '
+    '{name = "a", region = "europe-west1", ip_cidr_range = "10.0.0.0/24",'
+    '   secondary_ip_range=null},'
+    '{name = "b", region = "europe-west1", ip_cidr_range = "10.0.1.0/24",'
+    '   secondary_ip_range=null},'
+    '{name = "c", region = "europe-west1", ip_cidr_range = "10.0.2.0/24",'
+    '   secondary_ip_range={a="192.168.0.0/24", b="192.168.1.0/24"}},'
+    ']'
 )
 _VAR_LOG_CONFIG = '{a = { flow_sampling = 0.1 }}'
 _VAR_LOG_CONFIG_DEFAULTS = (
@@ -45,7 +45,7 @@ def test_subnets_simple(plan_runner):
   subnets = [r['values']
              for r in resources if r['type'] == 'google_compute_subnetwork']
   assert set(s['name'] for s in subnets) == set(
-      ['my-vpc-a', 'my-vpc-b', 'c'])
+      ['a', 'b', 'c'])
   assert set(len(s['secondary_ip_range']) for s in subnets) == set([0, 0, 2])
 
 
@@ -63,17 +63,17 @@ def test_subnet_log_configs(plan_runner):
     flow_logs[r['values']['name']] = r['values']['log_config']
   assert flow_logs == {
       # enable, override one default option
-      'my-vpc-a': [{
+      'europe-west1/a': [{
           'aggregation_interval': 'INTERVAL_10_MIN',
           'flow_sampling': 0.1,
           'metadata': 'INCLUDE_ALL_METADATA'
       }],
       # enable, use defaults
-      'my-vpc-b': [{
+      'europe-west1/b': [{
           'aggregation_interval': 'INTERVAL_10_MIN',
           'flow_sampling': 0.5,
           'metadata': 'INCLUDE_ALL_METADATA'
       }],
       # don't enable
-      'c': []
+      'europe-west1/c': []
   }


### PR DESCRIPTION
This changes `modules/net-vpc` to support subnets with the same name in different regions. I had to adapt the maps to accept subnet `region/name` keys instead of just `name`, which makes the end-to-end examples a bit uglier in some cases.

For that reason, If you prefer to not merge this and keep as it is I would understand, as in the end this repo is about simple/readable modules.