### PR TITLE
Adds clarification to gke-cluster module for node_config

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -45,9 +45,11 @@ resource "google_container_cluster" "cluster" {
   initial_node_count          = 1
   remove_default_node_pool    = true
 
-  # node_config
-  # TODO(ludomagno): compute addons map in locals and use a single dynamic block
+  # node_config {}
+  # NOTE: Default node_pool is deleted, so node_config (here) is extranneous.
+  # Specify that node_config as an parameter to gke-nodepool module instead.
 
+  # TODO(ludomagno): compute addons map in locals and use a single dynamic block
   addons_config {
     dns_cache_config {
       enabled = var.addons.dns_cache_config


### PR DESCRIPTION
I ended up in the `gke-cluster` module from [Shared VPC/GKE](https://github.com/terraform-google-modules/cloud-foundation-fabric/tree/master/infrastructure/shared-vpc-gke) because I wanted to configure various aspects of the node-pool. A note like this would have saved me having to figure out why we don't take node_config params to the `gke-cluster` module. 