### PR TITLE
Fix health checks in net-ilb and compute-mig modules

### DIFF
--- a/modules/compute-mig/main.tf
+++ b/modules/compute-mig/main.tf
@@ -257,9 +257,9 @@ resource "google_compute_region_instance_group_manager" "default" {
   }
 }
 
-resource "google_compute_health_check" "default" {
+resource "google_compute_health_check" "http" {
   provider    = google-beta
-  count       = var.health_check_config == null ? 0 : 1
+  count       = try(var.health_check_config.type, null) == "http" ? 1 : 0
   project     = var.project_id
   name        = var.name
   description = "Terraform managed."
@@ -269,92 +269,14 @@ resource "google_compute_health_check" "default" {
   timeout_sec         = try(var.health_check_config.config.timeout_sec, null)
   unhealthy_threshold = try(var.health_check_config.config.unhealthy_threshold, null)
 
-  dynamic http_health_check {
-    for_each = (
-      try(var.health_check_config.type, null) == "http"
-      ? [var.health_check_config.check]
-      : []
-    )
-    iterator = check
-    content {
-      host               = try(check.value.host, null)
-      port               = try(check.value.port, null)
-      port_name          = try(check.value.port_name, null)
-      port_specification = try(check.value.port_specification, null)
-      proxy_header       = try(check.value.proxy_header, null)
-      request_path       = try(check.value.request_path, null)
-      response           = try(check.value.response, null)
-    }
-  }
-
-  dynamic https_health_check {
-    for_each = (
-      try(var.health_check_config.type, null) == "https"
-      ? [var.health_check_config.check]
-      : []
-    )
-    iterator = check
-    content {
-      host               = try(check.value.host, null)
-      port               = try(check.value.port, null)
-      port_name          = try(check.value.port_name, null)
-      port_specification = try(check.value.port_specification, null)
-      proxy_header       = try(check.value.proxy_header, null)
-      request_path       = try(check.value.request_path, null)
-      response           = try(check.value.response, null)
-    }
-  }
-
-  dynamic tcp_health_check {
-    for_each = (
-      try(var.health_check_config.type, null) == "tcp"
-      ? [var.health_check_config.check]
-      : []
-    )
-    iterator = check
-    content {
-      port               = try(check.value.port, null)
-      port_name          = try(check.value.port_name, null)
-      port_specification = try(check.value.port_specification, null)
-      proxy_header       = try(check.value.proxy_header, null)
-      request            = try(check.value.request, null)
-      response           = try(check.value.response, null)
-    }
-  }
-
-  dynamic ssl_health_check {
-    for_each = (
-      try(var.health_check_config.type, null) == "ssl"
-      ? [var.health_check_config.check]
-      : []
-    )
-    iterator = check
-    content {
-      port               = try(check.value.port, null)
-      port_name          = try(check.value.port_name, null)
-      port_specification = try(check.value.port_specification, null)
-      proxy_header       = try(check.value.proxy_header, null)
-      request            = try(check.value.request, null)
-      response           = try(check.value.response, null)
-    }
-  }
-
-  dynamic http2_health_check {
-    for_each = (
-      try(var.health_check_config.type, null) == "http2"
-      ? [var.health_check_config.check]
-      : []
-    )
-    iterator = check
-    content {
-      host               = try(check.value.host, null)
-      port               = try(check.value.port, null)
-      port_name          = try(check.value.port_name, null)
-      port_specification = try(check.value.port_specification, null)
-      proxy_header       = try(check.value.proxy_header, null)
-      request_path       = try(check.value.request_path, null)
-      response           = try(check.value.response, null)
-    }
+  http_health_check {
+    host               = try(var.health_check_config.check.host, null)
+    port               = try(var.health_check_config.check.port, null)
+    port_name          = try(var.health_check_config.check.port_name, null)
+    port_specification = try(var.health_check_config.check.port_specification, null)
+    proxy_header       = try(var.health_check_config.check.proxy_header, null)
+    request_path       = try(var.health_check_config.check.request_path, null)
+    response           = try(var.health_check_config.check.response, null)
   }
 
   dynamic log_config {
@@ -363,5 +285,122 @@ resource "google_compute_health_check" "default" {
       enable = true
     }
   }
+}
 
+resource "google_compute_health_check" "https" {
+  provider    = google-beta
+  count       = try(var.health_check_config.type, null) == "https" ? 1 : 0
+  project     = var.project_id
+  name        = var.name
+  description = "Terraform managed."
+
+  check_interval_sec  = try(var.health_check_config.config.check_interval_sec, null)
+  healthy_threshold   = try(var.health_check_config.config.healthy_threshold, null)
+  timeout_sec         = try(var.health_check_config.config.timeout_sec, null)
+  unhealthy_threshold = try(var.health_check_config.config.unhealthy_threshold, null)
+
+  https_health_check {
+    host               = try(var.health_check_config.check.host, null)
+    port               = try(var.health_check_config.check.port, null)
+    port_name          = try(var.health_check_config.check.port_name, null)
+    port_specification = try(var.health_check_config.check.port_specification, null)
+    proxy_header       = try(var.health_check_config.check.proxy_header, null)
+    request_path       = try(var.health_check_config.check.request_path, null)
+    response           = try(var.health_check_config.check.response, null)
+  }
+
+  dynamic log_config {
+    for_each = try(var.health_check_config.logging, false) ? [""] : []
+    content {
+      enable = true
+    }
+  }
+}
+
+resource "google_compute_health_check" "tcp" {
+  provider    = google-beta
+  count       = try(var.health_check_config.type, null) == "tcp" ? 1 : 0
+  project     = var.project_id
+  name        = var.name
+  description = "Terraform managed."
+
+  check_interval_sec  = try(var.health_check_config.config.check_interval_sec, null)
+  healthy_threshold   = try(var.health_check_config.config.healthy_threshold, null)
+  timeout_sec         = try(var.health_check_config.config.timeout_sec, null)
+  unhealthy_threshold = try(var.health_check_config.config.unhealthy_threshold, null)
+
+  tcp_health_check {
+    port               = try(var.health_check_config.check.port, null)
+    port_name          = try(var.health_check_config.check.port_name, null)
+    port_specification = try(var.health_check_config.check.port_specification, null)
+    proxy_header       = try(var.health_check_config.check.proxy_header, null)
+    request            = try(var.health_check_config.check.request, null)
+    response           = try(var.health_check_config.check.response, null)
+  }
+
+  dynamic log_config {
+    for_each = try(var.health_check_config.logging, false) ? [""] : []
+    content {
+      enable = true
+    }
+  }
+}
+
+resource "google_compute_health_check" "ssl" {
+  provider    = google-beta
+  count       = try(var.health_check_config.type, null) == "ssl" ? 1 : 0
+  project     = var.project_id
+  name        = var.name
+  description = "Terraform managed."
+
+  check_interval_sec  = try(var.health_check_config.config.check_interval_sec, null)
+  healthy_threshold   = try(var.health_check_config.config.healthy_threshold, null)
+  timeout_sec         = try(var.health_check_config.config.timeout_sec, null)
+  unhealthy_threshold = try(var.health_check_config.config.unhealthy_threshold, null)
+
+  ssl_health_check {
+    port               = try(var.health_check_config.check.port, null)
+    port_name          = try(var.health_check_config.check.port_name, null)
+    port_specification = try(var.health_check_config.check.port_specification, null)
+    proxy_header       = try(var.health_check_config.check.proxy_header, null)
+    request            = try(var.health_check_config.check.request, null)
+    response           = try(var.health_check_config.check.response, null)
+  }
+
+  dynamic log_config {
+    for_each = try(var.health_check_config.logging, false) ? [""] : []
+    content {
+      enable = true
+    }
+  }
+}
+
+resource "google_compute_health_check" "http2" {
+  provider    = google-beta
+  count       = try(var.health_check_config.type, null) == "http2" ? 1 : 0
+  project     = var.project_id
+  name        = var.name
+  description = "Terraform managed."
+
+  check_interval_sec  = try(var.health_check_config.config.check_interval_sec, null)
+  healthy_threshold   = try(var.health_check_config.config.healthy_threshold, null)
+  timeout_sec         = try(var.health_check_config.config.timeout_sec, null)
+  unhealthy_threshold = try(var.health_check_config.config.unhealthy_threshold, null)
+
+  http2_health_check {
+    host               = try(var.health_check_config.check.host, null)
+    port               = try(var.health_check_config.check.port, null)
+    port_name          = try(var.health_check_config.check.port_name, null)
+    port_specification = try(var.health_check_config.check.port_specification, null)
+    proxy_header       = try(var.health_check_config.check.proxy_header, null)
+    request_path       = try(var.health_check_config.check.request_path, null)
+    response           = try(var.health_check_config.check.response, null)
+  }
+
+  dynamic log_config {
+    for_each = try(var.health_check_config.logging, false) ? [""] : []
+    content {
+      enable = true
+    }
+  }
 }

--- a/modules/compute-mig/outputs.tf
+++ b/modules/compute-mig/outputs.tf
@@ -34,7 +34,16 @@ output "group_manager" {
 
 output "health_check" {
   description = "Auto-created health-check resource."
-  value = var.health_check_config == null ? null : try(
-    google_compute_health_check.default.0, {}
+  value = (
+    var.health_check_config == null
+    ? null
+    : try(
+      google_compute_health_check.http.0,
+      google_compute_health_check.https.0,
+      google_compute_health_check.tcp.0,
+      google_compute_health_check.ssl.0,
+      google_compute_health_check.http2.0,
+      {}
+    )
   )
 }

--- a/modules/net-ilb/outputs.tf
+++ b/modules/net-ilb/outputs.tf
@@ -51,15 +51,15 @@ output "forwarding_rule_self_link" {
 
 output "health_check" {
   description = "Auto-created health-check resource."
-  value       = try(google_compute_health_check.default.0, {})
+  value       = local.health_check_resource
 }
 
 output "health_check_self_id" {
   description = "Auto-created health-check self id."
-  value       = try(google_compute_health_check.default.0.id, null)
+  value       = try(local.health_check_resource.id, null)
 }
 
 output "health_check_self_link" {
   description = "Auto-created health-check self link."
-  value       = try(google_compute_health_check.default.0.self_link, null)
+  value       = try(local.health_check_resource.self_link, null)
 }

--- a/tests/modules/compute_mig/__init__.py
+++ b/tests/modules/compute_mig/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/compute_mig/fixture/main.tf
+++ b/tests/modules/compute_mig/fixture/main.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source      = "../../../../modules/compute-mig"
+  project_id  = "my-project"
+  location    = "europe-west1"
+  name        = "test-mig"
+  target_size = 2
+  default_version = {
+    instance_template = "foo-template"
+    name              = "foo"
+  }
+  autoscaler_config   = var.autoscaler_config
+  health_check_config = var.health_check_config
+  named_ports         = var.named_ports
+  regional            = var.regional
+  update_policy       = var.update_policy
+  versions            = var.versions
+}

--- a/tests/modules/compute_mig/fixture/variables.tf
+++ b/tests/modules/compute_mig/fixture/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 variable "autoscaler_config" {
-  description = "Optional autoscaler configuration. Only one of 'cpu_utilization_target' 'load_balancing_utilization_target' or 'metric' can be not null."
   type = object({
     max_replicas                      = number
     min_replicas                      = number
@@ -34,7 +33,6 @@ variable "autoscaler_config" {
 }
 
 variable "auto_healing_policies" {
-  description = "Auto-healing policies for this group."
   type = object({
     health_check      = string
     initial_delay_sec = number
@@ -42,16 +40,7 @@ variable "auto_healing_policies" {
   default = null
 }
 
-variable "default_version" {
-  description = "Default application version template. Additional versions can be specified via the `versions` variable."
-  type = object({
-    instance_template = string
-    name              = string
-  })
-}
-
 variable "health_check_config" {
-  description = "Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage."
   type = object({
     type    = string      # http https tcp ssl http2
     check   = map(any)    # actual health check block attributes
@@ -61,47 +50,17 @@ variable "health_check_config" {
   default = null
 }
 
-variable "location" {
-  description = "Compute zone, or region if `regional` is set to true."
-  type        = string
-}
-
-variable "name" {
-  description = "Managed group name."
-  type        = string
-}
-
 variable "named_ports" {
-  description = "Named ports."
-  type        = map(number)
-  default     = null
-}
-
-variable "project_id" {
-  description = "Project id."
-  type        = string
+  type    = map(number)
+  default = null
 }
 
 variable "regional" {
-  description = "Use regional instance group. When set, `location` should be set to the region."
-  type        = bool
-  default     = false
-}
-
-variable "target_pools" {
-  description = "Optional list of URLs for target pools to which new instances in the group are added."
-  type        = list(string)
-  default     = []
-}
-
-variable "target_size" {
-  description = "Group target size, leave null when using an autoscaler."
-  type        = number
-  default     = null
+  type    = bool
+  default = false
 }
 
 variable "update_policy" {
-  description = "Update policy. Type can be 'OPPORTUNISTIC' or 'PROACTIVE', action 'REPLACE' or 'restart', surge type 'fixed' or 'percent'."
   type = object({
     type                 = string # OPPORTUNISTIC | PROACTIVE
     minimal_action       = string # REPLACE | RESTART
@@ -115,17 +74,10 @@ variable "update_policy" {
 }
 
 variable "versions" {
-  description = "Additional application versions, target_type is either 'fixed' or 'percent'."
   type = map(object({
     instance_template = string
     target_type       = string # fixed | percent
     target_size       = number
   }))
   default = null
-}
-
-variable "wait_for_instances" {
-  description = "Wait for all instances to be created/updated before returning."
-  type        = bool
-  default     = null
 }

--- a/tests/modules/compute_mig/test_plan.py
+++ b/tests/modules/compute_mig/test_plan.py
@@ -1,0 +1,73 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import pytest
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
+
+
+def test_defaults(plan_runner):
+  "Test variable defaults."
+  _, resources = plan_runner(FIXTURES_DIR)
+  assert len(resources) == 1
+  mig = resources[0]
+  assert mig['type'] == 'google_compute_instance_group_manager'
+  assert mig['values']['target_size'] == 2
+  assert mig['values']['zone']
+  _, resources = plan_runner(FIXTURES_DIR, regional='true')
+  assert len(resources) == 1
+  mig = resources[0]
+  assert mig['type'] == 'google_compute_region_instance_group_manager'
+  assert mig['values']['target_size'] == 2
+  assert mig['values']['region']
+
+
+def test_health_check(plan_runner):
+  "Test health check resource."
+  health_check_config = '{type="tcp", check={port=80}, config=null, logging=false}'
+  _, resources = plan_runner(
+      FIXTURES_DIR, health_check_config=health_check_config)
+  assert len(resources) == 2
+  assert any(r['type'] == 'google_compute_health_check' for r in resources)
+
+
+def test_autoscaler(plan_runner):
+  "Test autoscaler resource."
+  autoscaler_config = (
+      '{'
+      'max_replicas=3, min_replicas=1, cooldown_period=60,'
+      'cpu_utilization_target=65, load_balancing_utilization_target=null,'
+      'metric=null'
+      '}'
+  )
+  _, resources = plan_runner(FIXTURES_DIR, autoscaler_config=autoscaler_config)
+  assert len(resources) == 2
+  autoscaler = resources[0]
+  assert autoscaler['type'] == 'google_compute_autoscaler'
+  assert autoscaler['values']['autoscaling_policy'] == [{
+      'cooldown_period': 60,
+      'cpu_utilization': [{'target': 65}],
+      'load_balancing_utilization': [],
+      'max_replicas': 3,
+      'metric': [],
+      'min_replicas': 1
+  }]
+  _, resources = plan_runner(
+      FIXTURES_DIR, autoscaler_config=autoscaler_config, regional='true')
+  assert len(resources) == 2
+  autoscaler = resources[0]
+  assert autoscaler['type'] == 'google_compute_region_autoscaler'


### PR DESCRIPTION
A single health check resource with dynamic blocks for all types does not seem to work anymore, as tests are failing. This changes the `net-ilb` and `compute-mig` modules so that there's now one health check resource per type. A future PR might split out health checks int their own separate module so as to avoid code duplication.