### PR TITLE
Better service account outputs in project module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **incompatible change** robot and default service accounts outputs in the `project` module have been refactored and are now exposed via a single `service_account` output (cf [#82])
+
 ## [1.7.0] - 2020-05-30
 
 - add support for disk encryption to the `compute-vm` module

--- a/infrastructure/shared-vpc-gke/main.tf
+++ b/infrastructure/shared-vpc-gke/main.tf
@@ -31,7 +31,7 @@ module "project-host" {
   ]
   iam_members = {
     "roles/container.hostServiceAgentUser" = [
-      "serviceAccount:${module.project-svc-gke.gke_service_account}"
+      "serviceAccount:${module.project-svc-gke.service_accounts.robots.container-engine}"
     ]
     "roles/owner" = var.owners_host
   }
@@ -126,7 +126,7 @@ module "vpc-shared" {
         "serviceAccount:${module.project-svc-gke.service_accounts.robots.container-engine}",
       ])
       "roles/compute.securityAdmin" = [
-        "serviceAccount:${module.project-svc-gke.robots.container-engine}",
+        "serviceAccount:${module.project-svc-gke.service_accounts.robots.container-engine}",
       ]
     }
   }

--- a/infrastructure/shared-vpc-gke/main.tf
+++ b/infrastructure/shared-vpc-gke/main.tf
@@ -117,16 +117,16 @@ module "vpc-shared" {
   iam_members = {
     "${var.region}/gce" = {
       "roles/compute.networkUser" = concat(var.owners_gce, [
-        "serviceAccount:${module.project-svc-gce.cloudsvc_service_account}",
+        "serviceAccount:${module.project-svc-gce.service_accounts.cloud_services}",
       ])
     }
     "${var.region}/gke" = {
       "roles/compute.networkUser" = concat(var.owners_gke, [
-        "serviceAccount:${module.project-svc-gke.cloudsvc_service_account}",
-        "serviceAccount:${module.project-svc-gke.gke_service_account}",
+        "serviceAccount:${module.project-svc-gke.service_accounts.cloud_services}",
+        "serviceAccount:${module.project-svc-gke.service_accounts.robots.container-engine}",
       ])
       "roles/compute.securityAdmin" = [
-        "serviceAccount:${module.project-svc-gke.gke_service_account}",
+        "serviceAccount:${module.project-svc-gke.robots.container-engine}",
       ]
     }
   }

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -80,12 +80,9 @@ module "project" {
 
 | name | description | sensitive |
 |---|---|:---:|
-| cloudsvc_service_account | Cloud services service account. |  |
 | custom_roles | Ids of the created custom roles. |  |
-| gce_service_account | Default GCE service account. |  |
-| gcr_service_account | Default GCR service account. |  |
-| gke_service_account | Default GKE service account. |  |
 | name | Project ame. |  |
 | number | Project number. |  |
 | project_id | Project id. |  |
+| service_accounts | Product robot service accounts in project. |  |
 <!-- END TFDOC -->

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -15,10 +15,6 @@
  */
 
 locals {
-  cloudsvc_service_account = "${google_project.project.number}@cloudservices.gserviceaccount.com"
-  gce_service_account      = "${google_project.project.number}-compute@developer.gserviceaccount.com"
-  gcr_service_account      = "service-${google_project.project.number}@containerregistry.iam.gserviceaccount.com"
-  gke_service_account      = "service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
   iam_additive_pairs = flatten([
     for role in var.iam_additive_roles : [
       for member in lookup(var.iam_additive_members, role, []) :

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -44,28 +44,14 @@ output "number" {
   ]
 }
 
-output "cloudsvc_service_account" {
-  description = "Cloud services service account."
-  value       = "${local.cloudsvc_service_account}"
-  depends_on  = [google_project_service.project_services]
-}
-
-output "gce_service_account" {
-  description = "Default GCE service account."
-  value       = local.gce_service_account
-  depends_on  = [google_project_service.project_services]
-}
-
-output "gcr_service_account" {
-  description = "Default GCR service account."
-  value       = local.gcr_service_account
-  depends_on  = [google_project_service.project_services]
-}
-
-output "gke_service_account" {
-  description = "Default GKE service account."
-  value       = local.gke_service_account
-  depends_on  = [google_project_service.project_services]
+output "service_accounts" {
+  description = "Product robot service accounts in project."
+  value = {
+    cloud_services = local.service_account_cloud_services
+    default        = local.service_accounts_default
+    robots         = local.service_accounts_robots
+  }
+  depends_on = [google_project_service.project_services]
 }
 
 output "custom_roles" {

--- a/modules/project/service_accounts.tf
+++ b/modules/project/service_accounts.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  service_account_cloud_services = "${google_project.project.number}@cloudservices.gserviceaccount.com"
+  service_accounts_default = {
+    compute = "${google_project.project.number}-compute@developer.gserviceaccount.com"
+  }
+  service_accounts_robot_services = {
+    compute           = "compute-system",
+    container-engine  = "container-engine-robot",
+    containerregistry = "containerregistry",
+    dataproc          = "dataproc-accounts",
+    gcf               = "gcf-admin-robot",
+    pubsub            = "gcp-sa-pubsub"
+  }
+  service_accounts_robots = {
+    for service, name in local.service_accounts_robot_services :
+    service => "service-${google_project.project.number}@${name}.iam.gserviceaccount.com"
+  }
+}

--- a/modules/project/service_accounts.tf
+++ b/modules/project/service_accounts.tf
@@ -18,14 +18,19 @@ locals {
   service_account_cloud_services = "${google_project.project.number}@cloudservices.gserviceaccount.com"
   service_accounts_default = {
     compute = "${google_project.project.number}-compute@developer.gserviceaccount.com"
+    gae     = "${google_project.project.project_id}@appspot.gserviceaccount.com"
   }
   service_accounts_robot_services = {
-    compute           = "compute-system",
-    container-engine  = "container-engine-robot",
-    containerregistry = "containerregistry",
-    dataproc          = "dataproc-accounts",
-    gcf               = "gcf-admin-robot",
+    cloudasset        = "gcp-sa-cloudasset"
+    cloudbuild        = "gcp-sa-cloudbuild"
+    compute           = "compute-system"
+    container-engine  = "container-engine-robot"
+    containerregistry = "containerregistry"
+    dataproc          = "dataproc-accounts"
+    gae-flex          = "gae-api-prod"
+    gcf               = "gcf-admin-robot"
     pubsub            = "gcp-sa-pubsub"
+    storage           = "gs-project-accounts"
   }
   service_accounts_robots = {
     for service, name in local.service_accounts_robot_services :


### PR DESCRIPTION
This change rationalizes the way robot and default service accounts are exposed in the project module's outputs:

- all service accounts are exposed via a single `service_accounts` output
- the general/legacy service robot is exposed in `service_accounts.cloud_services`
- per-service robots are exposed in `service_accounts.robots`, eg `service_accounts.robots.container-engine`
- default service accounts are exposed in `service_accounts.default`, eg `service_accounts.default.compute`

Adding extra robot service accounts is done via the `local.service_accounts_robot_services` variable in the `service_accounts.tf` file which has been added in this PR.