### PR TITLE
Refactor service account module outputs

### DIFF
--- a/modules/iam-service-accounts/main.tf
+++ b/modules/iam-service-accounts/main.tf
@@ -54,31 +54,12 @@ locals {
       ]
     ]
   ])
-  keys = (
-    var.generate_keys
-    ? {
-      for name in var.names :
-      name => lookup(google_service_account_key.keys, name, null)
-    }
-    : {}
-  )
-  prefix = (
-    var.prefix != ""
-    ? "${var.prefix}-"
-    : ""
-  )
-  resource = (
-    length(var.names) > 0
-    ? lookup(local.resources, var.names[0], null)
-    : null
-  )
+  keys     = var.generate_keys ? google_service_account_key.keys : {}
+  prefix   = var.prefix != null ? "${var.prefix}-" : ""
+  resource = try(google_service_account.service_accounts[var.names[0]], null)
   resource_iam_emails = {
-    for name, resource in local.resources :
+    for name, resource in google_service_account.service_accounts :
     name => "serviceAccount:${resource.email}"
-  }
-  resources = {
-    for name in var.names :
-    name => lookup(google_service_account.service_accounts, name, null)
   }
 }
 

--- a/modules/iam-service-accounts/outputs.tf
+++ b/modules/iam-service-accounts/outputs.tf
@@ -21,27 +21,30 @@ output "service_account" {
 
 output "service_accounts" {
   description = "Service account resources."
-  value       = local.resources
+  value       = google_service_account.service_accounts
 }
 
 output "email" {
   description = "Service account email (for single use)."
-  value       = local.resource == null ? null : local.resource.email
+  value       = try(local.resource.email, null)
 }
 
 output "iam_email" {
   description = "IAM-format service account email (for single use)."
-  value       = local.resource == null ? null : "serviceAccount:${local.resource.email}"
+  value       = try("serviceAccount:${local.resource.email}", null)
 }
 
 output "key" {
   description = "Service account key (for single use)."
-  value       = lookup(local.keys, var.names[0], null)
+  value       = try(local.keys[var.names[0]], null)
 }
 
 output "emails" {
   description = "Service account emails."
-  value       = { for name, resource in local.resources : name => resource.email }
+  value = {
+    for name, resource in google_service_account.service_accounts :
+    name => resource.email
+  }
 }
 
 output "iam_emails" {
@@ -51,12 +54,18 @@ output "iam_emails" {
 
 output "emails_list" {
   description = "Service account emails."
-  value       = [for name, resource in local.resources : resource.email]
+  value = [
+    for name, resource in google_service_account.service_accounts :
+    resource.email
+  ]
 }
 
 output "iam_emails_list" {
   description = "IAM-format service account emails."
-  value       = [for name, resource in local.resources : "serviceAccount:${resource.email}"]
+  value = [
+    for name, resource in google_service_account.service_accounts :
+    "serviceAccount:${resource.email}"
+  ]
 }
 
 output "keys" {

--- a/modules/iam-service-accounts/variables.tf
+++ b/modules/iam-service-accounts/variables.tf
@@ -20,23 +20,6 @@ variable "generate_keys" {
   default     = false
 }
 
-variable "names" {
-  description = "Names of the service accounts to create."
-  type        = list(string)
-  default     = []
-}
-
-variable "prefix" {
-  description = "Prefix applied to service account names."
-  type        = string
-  default     = ""
-}
-
-variable "project_id" {
-  description = "Project id where service account will be created."
-  type        = string
-}
-
 variable "iam_members" {
   description = "Map of member lists which are granted authoritative roles on the service accounts, keyed by role."
   type        = map(list(string))
@@ -77,4 +60,21 @@ variable "iam_storage_roles" {
   description = "Storage roles granted to all service accounts, by bucket name."
   type        = map(list(string))
   default     = {}
+}
+
+variable "names" {
+  description = "Names of the service accounts to create."
+  type        = list(string)
+  default     = []
+}
+
+variable "prefix" {
+  description = "Prefix applied to service account names."
+  type        = string
+  default     = null
+}
+
+variable "project_id" {
+  description = "Project id where service account will be created."
+  type        = string
 }

--- a/tests/modules/iam_service_accounts/__init__.py
+++ b/tests/modules/iam_service_accounts/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/iam_service_accounts/fixture/main.tf
+++ b/tests/modules/iam_service_accounts/fixture/main.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source                 = "../../../../modules/iam-service-accounts"
+  project_id             = var.project_id
+  names                  = ["sa-one", "sa-two", "sa-three"]
+  prefix                 = var.prefix
+  generate_keys          = var.generate_keys
+  iam_members            = var.iam_members
+  iam_roles              = var.iam_roles
+  iam_billing_roles      = var.iam_billing_roles
+  iam_folder_roles       = var.iam_folder_roles
+  iam_organization_roles = var.iam_organization_roles
+  iam_project_roles      = var.iam_project_roles
+  iam_storage_roles      = var.iam_storage_roles
+}

--- a/tests/modules/iam_service_accounts/fixture/variables.tf
+++ b/tests/modules/iam_service_accounts/fixture/variables.tf
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "generate_keys" {
+  type    = bool
+  default = false
+}
+
+variable "iam_members" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "iam_roles" {
+  type    = list(string)
+  default = []
+}
+
+variable "iam_billing_roles" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "iam_folder_roles" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "iam_organization_roles" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "iam_project_roles" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "iam_storage_roles" {
+  type    = map(list(string))
+  default = {}
+}
+
+variable "prefix" {
+  type    = string
+  default = null
+}
+
+variable "project_id" {
+  type    = string
+  default = "my-project"
+}

--- a/tests/modules/iam_service_accounts/test_plan.py
+++ b/tests/modules/iam_service_accounts/test_plan.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import pytest
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
+
+
+def test_resources(plan_runner):
+  "Test service account resource."
+  _, resources = plan_runner(FIXTURES_DIR)
+  assert len(resources) == 3
+  assert set(r['type'] for r in resources) == set(['google_service_account'])
+  assert set(r['values']['account_id'] for r in resources) == set([
+      'sa-one', 'sa-two', 'sa-three'
+  ])
+  _, resources = plan_runner(FIXTURES_DIR, prefix='foo')
+  assert set(r['values']['account_id'] for r in resources) == set([
+      'foo-sa-one', 'foo-sa-two', 'foo-sa-three'
+  ])
+
+
+def test_iam_roles(plan_runner):
+  "Test iam roles with no memmbers."
+  _, resources = plan_runner(FIXTURES_DIR,
+                             iam_roles='["roles/iam.serviceAccountUser"]')
+  assert len(resources) == 6
+  iam_resources = [r for r in resources if r['type']
+                   != 'google_service_account']
+  assert len(iam_resources) == 3
+  assert set(r['type'] for r in iam_resources) == set(
+      ['google_service_account_iam_binding'])
+  assert [r['index'] for r in iam_resources] == [
+      'sa-one-roles/iam.serviceAccountUser',
+      'sa-three-roles/iam.serviceAccountUser',
+      'sa-two-roles/iam.serviceAccountUser',
+  ]


### PR DESCRIPTION
This updates a few leftovers from the old versions in the service account module, and hopefully makes outputs more resilient to corner cases like a service account being deleted outside of Terraform, where old outputs tended to raise errors.

The changes should be backward-compatible.