### PR TITLE
Added PD CSI Driver Addon support

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -75,6 +75,9 @@ resource "google_container_cluster" "cluster" {
       disabled = ! var.addons.istio_config.enabled
       auth     = var.addons.istio_config.tls ? "AUTH_MUTUAL_TLS" : "AUTH_NONE"
     }
+    gce_persistent_disk_csi_driver_config {
+      enabled = var.addons.gce_persistent_disk_csi_driver_config
+    }
   }
 
   # TODO(ludomagno): support setting address ranges instead of range names

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -26,6 +26,7 @@ variable "addons" {
       tls     = bool
     })
     network_policy_config = bool
+    gce_persistent_disk_csi_driver_config = bool
   })
   default = {
     cloudrun_config            = false
@@ -37,6 +38,7 @@ variable "addons" {
       tls     = false
     }
     network_policy_config = false
+    gce_persistent_disk_csi_driver_config = false
   }
 }
 


### PR DESCRIPTION
Google supports CSI Driver for PD (https://cloud.google.com/kubernetes-engine/docs/how-to/gce-pd-csi-driver) which is also supported by TF Google Beta Provider (https://www.terraform.io/docs/providers/google/r/container_cluster.html#gce_persistent_disk_csi_driver_config)