### PR TITLE
dns_keys output added to the dns module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - **incompatible change** routes in the `net-vpc` module now interpolate the VPC name to ensure uniqueness, upgrading from a previous version will drop and recreate routes
 - the top-level `docker-images` folder has been moved inside `modules/cloud-config-container/onprem`
+- `dns_keys` output added to the `dns` module
 
 ## [2.0.0] - 2020-06-11
 

--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -43,6 +43,7 @@ module "private-dns" {
 
 | name | description | sensitive |
 |---|---|:---:|
+| dns_keys | DNSKEY and DS records of DNSSEC-signed managed zones. |  |
 | domain | The DNS zone domain. |  |
 | name | The DNS zone name. |  |
 | name_servers | The DNS zone name servers. |  |

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -15,7 +15,6 @@
  */
 
 locals {
-  is_static_zone = var.type == "public" || var.type == "private"
   recordsets = var.recordsets == null ? {} : {
     for record in var.recordsets :
     join("/", [record.name, record.type]) => record
@@ -24,6 +23,9 @@ locals {
     google_dns_managed_zone.non-public.0, try(
       google_dns_managed_zone.public.0, null
     )
+  )
+  dns_keys = try(
+    data.google_dns_keys.dns_keys.0, null
   )
 }
 
@@ -118,6 +120,11 @@ resource "google_dns_managed_zone" "public" {
     }
   }
 
+}
+
+data "google_dns_keys" "dns_keys" {
+  count        = var.dnssec_config == {} && var.type != "public" ? 0 : 1
+  managed_zone = google_dns_managed_zone.public.0.id
 }
 
 resource "google_dns_record_set" "cloud-static-records" {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -123,7 +123,7 @@ resource "google_dns_managed_zone" "public" {
 }
 
 data "google_dns_keys" "dns_keys" {
-  count        = var.dnssec_config == {} && var.type != "public" ? 0 : 1
+  count        = var.dnssec_config == {} || var.type != "public" ? 0 : 1
   managed_zone = google_dns_managed_zone.public.0.id
 }
 

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -38,3 +38,8 @@ output "name_servers" {
   description = "The DNS zone name servers."
   value       = try(local.zone.name_servers, null)
 }
+
+output "dns_keys" {
+  description = "DNSKEY and DS records of DNSSEC-signed managed zones."
+  value       = local.dns_keys
+}

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -15,5 +15,9 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.20"
+  required_providers {
+    google      = "~> 3.10"
+    google-beta = "~> 3.10"
+  }
 }


### PR DESCRIPTION
`dns_keys` output added to the `dns` module, so things like DS entry will be outputed if DNSSEC configuration is provided