### PR TITLE
Make project creation optional in project module

### DIFF
--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -58,9 +58,8 @@ module "project" {
 | name | description | type | required | default |
 |---|---|:---: |:---:|:---:|
 | name | Project name and id suffix. | <code title="">string</code> | ✓ |  |
-| parent | The resource name of the parent Folder or Organization. Must be of the form folders/folder_id or organizations/org_id. | <code title="">string</code> | ✓ |  |
 | *auto_create_network* | Whether to create the default network for the project | <code title="">bool</code> |  | <code title="">false</code> |
-| *billing_account* | Billing account id. | <code title="">string</code> |  | <code title=""></code> |
+| *billing_account* | Billing account id. | <code title="">string</code> |  | <code title="">null</code> |
 | *custom_roles* | Map of role name => list of permissions to create in this project. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_members* | Map of member lists used to set non authoritative bindings, keyed by role. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_roles* | List of roles used to set non authoritative bindings. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
@@ -71,6 +70,7 @@ module "project" {
 | *oslogin* | Enable OS Login. | <code title="">bool</code> |  | <code title="">false</code> |
 | *oslogin_admins* | List of IAM-style identities that will be granted roles necessary for OS Login administrators. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *oslogin_users* | List of IAM-style identities that will be granted roles necessary for OS Login users. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
+| *parent* | Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format. | <code title="">string</code> |  | <code title="">null</code> |
 | *policy_boolean* | Map of boolean org policies and enforcement value, set value to null for policy restore. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
 | *policy_list* | Map of list org policies, status is true for allow, false for deny, null for restore. Values can only be used for allow or deny. | <code title="map&#40;object&#40;&#123;&#10;inherit_from_parent &#61; bool&#10;suggested_value     &#61; string&#10;status              &#61; bool&#10;values              &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 | *prefix* | Prefix used to generate project id and name. | <code title="">string</code> |  | <code title="">null</code> |

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -74,6 +74,7 @@ module "project" {
 | *policy_boolean* | Map of boolean org policies and enforcement value, set value to null for policy restore. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
 | *policy_list* | Map of list org policies, status is true for allow, false for deny, null for restore. Values can only be used for allow or deny. | <code title="map&#40;object&#40;&#123;&#10;inherit_from_parent &#61; bool&#10;suggested_value     &#61; string&#10;status              &#61; bool&#10;values              &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 | *prefix* | Prefix used to generate project id and name. | <code title="">string</code> |  | <code title="">null</code> |
+| *project_create* | Create project. When set to false, uses a data source to reference existing project. | <code title="">bool</code> |  | <code title="">true</code> |
 | *services* | Service APIs to enable. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 
 ## Outputs
@@ -81,7 +82,7 @@ module "project" {
 | name | description | sensitive |
 |---|---|:---:|
 | custom_roles | Ids of the created custom roles. |  |
-| name | Project ame. |  |
+| name | Project name. |  |
 | number | Project number. |  |
 | project_id | Project id. |  |
 | service_accounts | Product robot service accounts in project. |  |

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -75,6 +75,7 @@ module "project" {
 | *policy_list* | Map of list org policies, status is true for allow, false for deny, null for restore. Values can only be used for allow or deny. | <code title="map&#40;object&#40;&#123;&#10;inherit_from_parent &#61; bool&#10;suggested_value     &#61; string&#10;status              &#61; bool&#10;values              &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 | *prefix* | Prefix used to generate project id and name. | <code title="">string</code> |  | <code title="">null</code> |
 | *project_create* | Create project. When set to false, uses a data source to reference existing project. | <code title="">bool</code> |  | <code title="">true</code> |
+| *service_config* | Configure service API activation. | <code title="object&#40;&#123;&#10;disable_on_destroy         &#61; bool&#10;disable_dependent_services &#61; bool&#10;&#125;&#41;">object({...})</code> |  | <code title="&#123;&#10;disable_on_destroy         &#61; true&#10;disable_dependent_services &#61; true&#10;&#125;">...</code> |
 | *services* | Service APIs to enable. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 
 ## Outputs

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -25,8 +25,8 @@ locals {
     for pair in local.iam_additive_pairs :
     "${pair.role}-${pair.member}" => pair
   }
-  parent_type = split("/", var.parent)[0]
-  parent_id   = split("/", var.parent)[1]
+  parent_type = var.parent == null ? null : split("/", var.parent)[0]
+  parent_id   = var.parent == null ? null : split("/", var.parent)[1]
   prefix      = var.prefix == null ? "" : "${var.prefix}-"
   project = (
     var.project_create ? google_project.project.0 : data.google_project.project.0

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -79,8 +79,8 @@ resource "google_project_service" "project_services" {
   for_each                   = toset(var.services)
   project                    = local.project.project_id
   service                    = each.value
-  disable_on_destroy         = true
-  disable_dependent_services = true
+  disable_on_destroy         = var.service_config.disable_on_destroy
+  disable_dependent_services = var.service_config.disable_dependent_services
 }
 
 # IAM notes:

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -104,6 +104,10 @@ resource "google_project_iam_member" "additive" {
   project  = local.project.project_id
   role     = each.value.role
   member   = each.value.member
+  depends_on = [
+    google_project_service.project_services,
+    google_project_iam_custom_role.roles
+  ]
 }
 
 resource "google_project_iam_member" "oslogin_iam_serviceaccountuser" {

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -56,5 +56,8 @@ output "service_accounts" {
 
 output "custom_roles" {
   description = "Ids of the created custom roles."
-  value       = [for role in google_project_iam_custom_role.roles : role.role_id]
+  value = {
+    for name, role in google_project_iam_custom_role.roles :
+    name => role.id
+  }
 }

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -16,7 +16,7 @@
 
 output "project_id" {
   description = "Project id."
-  value       = google_project.project.project_id
+  value       = local.project.project_id
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,
@@ -25,8 +25,8 @@ output "project_id" {
 }
 
 output "name" {
-  description = "Project ame."
-  value       = google_project.project.name
+  description = "Project name."
+  value       = local.project.name
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,
@@ -36,7 +36,7 @@ output "name" {
 
 output "number" {
   description = "Project number."
-  value       = google_project.project.number
+  value       = local.project.number
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,

--- a/modules/project/service_accounts.tf
+++ b/modules/project/service_accounts.tf
@@ -15,10 +15,10 @@
  */
 
 locals {
-  service_account_cloud_services = "${google_project.project.number}@cloudservices.gserviceaccount.com"
+  service_account_cloud_services = "${local.project.number}@cloudservices.gserviceaccount.com"
   service_accounts_default = {
-    compute = "${google_project.project.number}-compute@developer.gserviceaccount.com"
-    gae     = "${google_project.project.project_id}@appspot.gserviceaccount.com"
+    compute = "${local.project.number}-compute@developer.gserviceaccount.com"
+    gae     = "${local.project.project_id}@appspot.gserviceaccount.com"
   }
   service_accounts_robot_services = {
     cloudasset        = "gcp-sa-cloudasset"
@@ -34,6 +34,6 @@ locals {
   }
   service_accounts_robots = {
     for service, name in local.service_accounts_robot_services :
-    service => "service-${google_project.project.number}@${name}.iam.gserviceaccount.com"
+    service => "service-${local.project.number}@${name}.iam.gserviceaccount.com"
   }
 }

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -130,3 +130,15 @@ variable "services" {
   type        = list(string)
   default     = []
 }
+
+variable "service_config" {
+  description = "Configure service API activation."
+  type = object({
+    disable_on_destroy         = bool
+    disable_dependent_services = bool
+  })
+  default = {
+    disable_on_destroy         = true
+    disable_dependent_services = true
+  }
+}

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -119,6 +119,12 @@ variable "prefix" {
   default     = null
 }
 
+variable "project_create" {
+  description = "Create project. When set to false, uses a data source to reference existing project."
+  type        = bool
+  default     = true
+}
+
 variable "services" {
   description = "Service APIs to enable."
   type        = list(string)

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -23,7 +23,7 @@ variable "auto_create_network" {
 variable "billing_account" {
   description = "Billing account id."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "custom_roles" {
@@ -92,8 +92,9 @@ variable "oslogin_users" {
 }
 
 variable "parent" {
-  description = "The resource name of the parent Folder or Organization. Must be of the form folders/folder_id or organizations/org_id."
+  description = "Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format."
   type        = string
+  default     = null
 }
 
 variable "policy_boolean" {

--- a/tests/modules/project/fixture/variables.tf
+++ b/tests/modules/project/fixture/variables.tf
@@ -71,7 +71,7 @@ variable "oslogin_users" {
 
 variable "parent" {
   type    = string
-  default = "folders/12345678"
+  default = null
 }
 
 variable "policy_boolean" {

--- a/tests/modules/project/test_plan.py
+++ b/tests/modules/project/test_plan.py
@@ -32,7 +32,7 @@ def test_prefix(plan_runner):
 
 def test_parent(plan_runner):
   "Test project parent."
-  _, resources = plan_runner(FIXTURES_DIR)
+  _, resources = plan_runner(FIXTURES_DIR, parent='folders/12345678')
   assert len(resources) == 1
   assert resources[0]['values']['folder_id'] == '12345678'
   assert resources[0]['values'].get('org_id') == None
@@ -40,3 +40,11 @@ def test_parent(plan_runner):
   assert len(resources) == 1
   assert resources[0]['values']['org_id'] == '12345678'
   assert resources[0]['values'].get('folder_id') == None
+
+
+def test_no_parent(plan_runner):
+  "Test null project parent."
+  _, resources = plan_runner(FIXTURES_DIR)
+  assert len(resources) == 1
+  assert resources[0]['values'].get('folder_id') == None
+  assert resources[0]['values'].get('org_id') == None


### PR DESCRIPTION
This allows using the project module to configure and customize pre-existing projects, without having to import them manually in state. It introduces count in the project resource, which works as far as I can understand but might need some extra testing especially with destroy.

This also adds a variable to optionally configure project API activation, useful in the situations above where you're referencing a pre-existing project, and need to activate extra APIs but don't want them to disable any depend APIs that were previously enabled.