### PR TITLE
Net address

### DIFF
--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -135,7 +135,7 @@ resource "google_compute_instance" "default" {
         iterator = nat_addresses
         content {
           nat_ip = nat_addresses.value == null ? null : (
-            length(nat_addresses.value) == 0 ? null : nat_addresses.value.external[each.value]
+            length(nat_addresses.value) == 0 ? null : nat_addresses.value[each.value]
           )
         }
       }

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -135,7 +135,7 @@ resource "google_compute_instance" "default" {
         iterator = nat_addresses
         content {
           nat_ip = nat_addresses.value == null ? null : (
-            length(nat_addresses.value) == 0 ? null : nat_addresses.value[each.value]
+            length(nat_addresses.value) == 0 ? null : nat_addresses.value.external[each.value]
           )
         }
       }

--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_address" "internal" {
   description  = "Terraform managed."
   address_type = "INTERNAL"
   region       = each.value.region
-  subnetwork   = each.value.subnetwork
+  subnetwork   = "projects/${each.value.host_project == "null" ? var.project_id : each.value.host_project}/regions/${each.value.region}/subnetworks/${each.value.subnetwork}"
   address      = lookup(var.internal_address_addresses, each.key, null)
   network_tier = lookup(var.internal_address_tiers, each.key, null)
   # labels       = lookup(var.internal_address_labels, each.key, {})

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -37,6 +37,7 @@ variable "internal_addresses" {
   type = map(object({
     region     = string
     subnetwork = string
+    host_project    = string
   }))
   default = {}
 }


### PR DESCRIPTION
Below modifications improves the "net-address" modules functionality by allowing it to reserve an Internal IP address is a Shared VPC architecture. An additional "host_project" entity in the existing "internal_addresses" variable can either be set to `"null"` or Hosts Project ID