### PR TITLE
Shared VPC- net address

### DIFF
--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_address" "internal" {
   description  = "Terraform managed."
   address_type = "INTERNAL"
   region       = each.value.region
-  subnetwork   = each.value.subnetwork
+  subnetwork   = "projects/${each.value.host_project == "null" ? var.project_id : each.value.host_project}/regions/${each.value.region}/subnetworks/${each.value.subnetwork}"
   address      = lookup(var.internal_address_addresses, each.key, null)
   network_tier = lookup(var.internal_address_tiers, each.key, null)
   # labels       = lookup(var.internal_address_labels, each.key, {})

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -37,6 +37,7 @@ variable "internal_addresses" {
   type = map(object({
     region     = string
     subnetwork = string
+    host_project = string
   }))
   default = {}
 }


### PR DESCRIPTION
With two simple modifications, net-address module now supports reservation of Internal IP addresses in a Shared VPC architecture.

Modification:
1. In an existing variable(internal_addresses), another entity has been added "host_project". Accepted values "null" or "host_project_id"
2. Based on the entity module decides which project to use
