### PR TITLE
Support Shared VPC in project module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- add support for Shielded VM to `compute-vm`
+- add support for Shielded VM to the `compute-vm` module
+- add support for Shared VPC to the `project` module
 
 ## [2.4.1] - 2020-07-06
 

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -103,6 +103,7 @@ module "project" {
 | *project_create* | Create project. When set to false, uses a data source to reference existing project. | <code title="">bool</code> |  | <code title="">true</code> |
 | *service_config* | Configure service API activation. | <code title="object&#40;&#123;&#10;disable_on_destroy         &#61; bool&#10;disable_dependent_services &#61; bool&#10;&#125;&#41;">object({...})</code> |  | <code title="&#123;&#10;disable_on_destroy         &#61; true&#10;disable_dependent_services &#61; true&#10;&#125;">...</code> |
 | *services* | Service APIs to enable. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
+| *shared_vpc_config* | Configure Shared VPC for project. | <code title="object&#40;&#123;&#10;enabled          &#61; bool&#10;service_projects &#61; list&#40;string&#41;&#10;&#125;&#41;">object({...})</code> |  | <code title="&#123;&#10;enabled          &#61; false&#10;service_projects &#61; &#91;&#93;&#10;&#125;">...</code> |
 
 ## Outputs
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -212,3 +212,19 @@ resource "google_project_organization_policy" "list" {
     }
   }
 }
+
+resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
+  count   = try(var.shared_vpc_config.enabled, false) ? 1 : 0
+  project = local.project.project_id
+}
+
+resource "google_compute_shared_vpc_service_project" "service_projects" {
+  for_each = (
+    try(var.shared_vpc_config.enabled, false)
+    ? toset(var.shared_vpc_config.service_projects)
+    : toset([])
+  )
+  host_project    = local.project.project_id
+  service_project = each.value
+  depends_on      = [google_compute_shared_vpc_host_project.shared_vpc_host]
+}

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -20,7 +20,8 @@ output "project_id" {
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,
-    google_project_service.project_services
+    google_project_service.project_services,
+    google_compute_shared_vpc_service_project
   ]
 }
 
@@ -30,7 +31,8 @@ output "name" {
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,
-    google_project_service.project_services
+    google_project_service.project_services,
+    google_compute_shared_vpc_service_project
   ]
 }
 
@@ -40,7 +42,8 @@ output "number" {
   depends_on = [
     google_project_organization_policy.boolean,
     google_project_organization_policy.list,
-    google_project_service.project_services
+    google_project_service.project_services,
+    google_compute_shared_vpc_service_project
   ]
 }
 

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -138,3 +138,15 @@ variable "service_config" {
     disable_dependent_services = true
   }
 }
+
+variable "shared_vpc_config" {
+  description = "Configure Shared VPC for project."
+  type = object({
+    enabled          = bool
+    service_projects = list(string)
+  })
+  default = {
+    enabled          = false
+    service_projects = []
+  }
+}


### PR DESCRIPTION
This adds support for Shared VPC at the project level, which is needed whenever you're not doing prototypes inside an existing project, and especially useful if you're managing a pre-existing project and VPC.