### PR TITLE
Add the option to not create a DNS managed zone

### DIFF
--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -38,6 +38,7 @@ module "private-dns" {
 | *recordsets* | List of DNS record objects to manage. | <code title="list&#40;object&#40;&#123;&#10;name    &#61; string&#10;type &#61; string&#10;ttl     &#61; number&#10;records &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list(object({...}))</code> |  | <code title="">[]</code> |
 | *service_directory_namespace* | Service directory namespace id (URL), only valid for 'service-directory' zone types. | <code title="">string</code> |  | <code title="">null</code> |
 | *type* | Type of zone to create, valid values are 'public', 'private', 'forwarding', 'peering', 'service-directory'. | <code title="">string</code> |  | <code title="">private</code> |
+| *zone_create* | Create zone. When set to false, uses a data source to reference existing project. | <code title="">bool</code> |  | <code title="">true</code> |
 
 ## Outputs
 

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -132,8 +132,8 @@ resource "google_dns_managed_zone" "public" {
 }
 
 data "google_dns_keys" "dns_keys" {
-  count        = var.dnssec_config == {} || var.type != "public" ? 0 : 1
-  managed_zone = google_dns_managed_zone.public.0.id
+  count        = var.zone_create && ( var.dnssec_config == {} || var.type != "public" ) ? 0 : 1
+  managed_zone = local.zone.id
 }
 
 resource "google_dns_record_set" "cloud-static-records" {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -19,10 +19,14 @@ locals {
     for record in var.recordsets :
     join("/", [record.name, record.type]) => record
   }
-  zone = try(
-    google_dns_managed_zone.non-public.0, try(
-      google_dns_managed_zone.public.0, null
-    )
+  zone = (
+    var.zone_create
+    ? try(
+    	google_dns_managed_zone.non-public.0, try(
+      	  google_dns_managed_zone.public.0, null
+    	)
+      )
+    : try(data.google_dns_managed_zone.public.0, null)
   )
   dns_keys = try(
     data.google_dns_keys.dns_keys.0, null
@@ -30,7 +34,7 @@ locals {
 }
 
 resource "google_dns_managed_zone" "non-public" {
-  count       = var.type != "public" ? 1 : 0
+  count      = (var.zone_create && var.type != "public" ) ? 1 : 0
   provider    = google-beta
   project     = var.project_id
   name        = var.name
@@ -89,8 +93,13 @@ resource "google_dns_managed_zone" "non-public" {
 
 }
 
+data "google_dns_managed_zone" "public" {
+  count      = var.zone_create ? 0 : 1
+  name = var.name
+}
+
 resource "google_dns_managed_zone" "public" {
-  count       = var.type == "public" ? 1 : 0
+  count      = (var.zone_create && var.type == "public" ) ? 1 : 0
   project     = var.project_id
   name        = var.name
   dns_name    = var.domain

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -98,3 +98,11 @@ variable "type" {
   type        = string
   default     = "private"
 }
+
+variable "zone_create" {
+  description = "Create zone. When set to false, uses a data source to reference existing zone."
+  type        = bool
+  default     = true
+}
+
+

--- a/modules/organization/outputs.tf
+++ b/modules/organization/outputs.tf
@@ -18,7 +18,7 @@ output "org_id" {
   description = "Organization id dependent on module resources."
   value       = var.org_id
   depends_on = [
-    google_organization_iam_audit_config,
+    google_organization_iam_audit_config.config,
     google_organization_iam_binding.authoritative,
     google_organization_iam_custom_role.roles,
     google_organization_iam_member.additive,


### PR DESCRIPTION
This is code to make it optional to create the managed zone in the DNS module.
With this, it would be possible to split-up the record-sets in multiple modules.