### PR TITLE
Add support for internal address purpose (and possibly refactor variables)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 - fix error in `project` module
 
+- **incompatible change** make HA VPN Gateway creation optional for `net-vpn-ha` module. Now an existing HA VPN Gateway can be used. Updating to the new version of the module will cause VPN Gateway recreation which can be handled by `terraform state rm/terraform import` operations.  
+
 ## [3.1.0] - 2020-08-16
 
 - **incompatible change** add support for specifying a different project id in the GKE cluster module; if using the `peering_config` variable, `peering_config.project_id` now needs to be explicitly set, a `null` value will reuse the `project_id` variable for the peering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Fix GCS2BQ (issue: 128)
 - make VPC creation optional in `net-vpc` module to allow managing a pre-existing VPC
+- add retention_policy in `gcs` module
 
 ## [3.2.0] - 2020-08-29
 

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -93,9 +93,9 @@ module "buckets" {
 | *labels* | Labels to be attached to all buckets. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *location* | Bucket location. | <code title="">string</code> |  | <code title="">EU</code> |
 | *prefix* | Prefix used to generate the bucket name. | <code title="">string</code> |  | <code title="">null</code> |
+| *retention_policies* | Per-bucket retention policy. | <code title="map&#40;map&#40;string&#41;&#41;">map(map(string))</code> |  | <code title="">{}</code> |
 | *storage_class* | Bucket storage class. | <code title="">string</code> |  | <code title="">MULTI_REGIONAL</code> |
 | *versioning* | Optional map to set versioning keyed by name, defaults to false. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
-| *retention_policies* | Optional map to set up retention policy keyed by bucket name. | <code title="map&#40;bool&#41;">map(map(string))</code> |  | <code title="">{}</code> |
 
 ## Outputs
 

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -45,8 +45,35 @@ module "buckets" {
   iam_roles = {
     bucket-two = ["roles/storage.admin"]
   }
-  kms_keys = {
+  encryption_keys = {
     bucket-two = local.kms_key.self_link,
+  }
+}
+```
+
+### Example with retention policy
+
+```hcl
+module "buckets" {
+  source     = "./modules/gcs"
+  project_id = "myproject"
+  prefix     = "test"
+  names      = ["bucket-one", "bucket-two"]
+  bucket_policy_only = {
+    bucket-one = false
+  }
+  iam_members = {
+    bucket-two = {
+      "roles/storage.admin" = ["group:storage@example.com"]
+    }
+  }
+  iam_roles = {
+    bucket-two = ["roles/storage.admin"]
+  }
+
+  retention_policies = {
+    bucket-one = { retention_period = 100 , is_locked = true}
+    bucket-two = { retention_period = 900 }
   }
 }
 ```
@@ -68,6 +95,7 @@ module "buckets" {
 | *prefix* | Prefix used to generate the bucket name. | <code title="">string</code> |  | <code title="">null</code> |
 | *storage_class* | Bucket storage class. | <code title="">string</code> |  | <code title="">MULTI_REGIONAL</code> |
 | *versioning* | Optional map to set versioning keyed by name, defaults to false. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
+| *retention_policies* | Optional map to set up retention policy keyed by bucket name. | <code title="map&#40;bool&#41;">map(map(string))</code> |  | <code title="">{}</code> |
 
 ## Outputs
 

--- a/modules/gcs/variables.tf
+++ b/modules/gcs/variables.tf
@@ -83,3 +83,9 @@ variable "versioning" {
   type        = map(bool)
   default     = {}
 }
+
+variable "retention_policies" {
+  description = "Per-bucket retention policy."
+  type        = map(map(string))
+  default     = {}
+}

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -22,6 +22,7 @@ module "addresses" {
 | *external_addresses* | Map of external address regions, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *global_addresses* | List of global addresses to create. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *internal_address_addresses* | Optional explicit addresses for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
+| *internal_address_purposes* | Optional purpose for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *internal_address_tiers* | Optional network tiers for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *internal_addresses* | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;region     &#61; string&#10;subnetwork &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -21,10 +21,8 @@ module "addresses" {
 | project_id | Project where the addresses will be created. | <code title="">string</code> | ✓ |  |
 | *external_addresses* | Map of external address regions, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *global_addresses* | List of global addresses to create. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
-| *internal_address_addresses* | Optional explicit addresses for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
-| *internal_address_purposes* | Optional purpose for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
-| *internal_address_tiers* | Optional network tiers for internal addresses, keyed by name. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *internal_addresses* | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;region     &#61; string&#10;subnetwork &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
+| *internal_addresses_config* | Optional configuration for internal addresses, keyed by name. Unused options can be set to null. | <code title="map&#40;object&#40;&#123;&#10;address &#61; string&#10;purpose &#61; string&#10;tier    &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 
 ## Outputs
 

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -1,14 +1,46 @@
 # Net Address Reservation Module
 
-## Example
+This module allows reserving Compute Engine external, global, and internal addresses.
+
+## Examples
+
+### External and global addresses
 
 ```hcl
 module "addresses" {
   source     = "./modules/net-address"
   project_id = local.projects.host
   external_addresses = {
-    nat-1      = module.vpc.subnet_regions["default"],
-    vpn-remote = module.vpc.subnet_regions["default"],
+    nat-1      = var.region
+    vpn-remote = var.region
+  }
+  global_addresses = ["app-1", "app-2"]
+}
+```
+
+### Internal addresses
+
+```hcl
+module "addresses" {
+  source     = "./modules/net-address"
+  project_id = local.projects.host
+  internal_addresses = {
+    ilb-1      = {
+      region = var.region
+      subnetwork = module.vpc.subnet_self_links["${var.region}-test"]
+    }
+    ilb-2      = {
+      region = var.region
+      subnetwork = module.vpc.subnet_self_links["${var.region}-test"]
+    }
+  }
+  # optional configuration
+  internal_addresses_config = {
+    ilb-1 = {
+      address = null
+      purpose = "SHARED_LOADBALANCER_VIP"
+      tier = null
+    }
   }
 }
 ```

--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -31,6 +31,7 @@ resource "google_compute_address" "external" {
 }
 
 resource "google_compute_address" "internal" {
+  provider     = google-beta
   for_each     = var.internal_addresses
   project      = var.project_id
   name         = each.key
@@ -40,5 +41,6 @@ resource "google_compute_address" "internal" {
   subnetwork   = each.value.subnetwork
   address      = lookup(var.internal_address_addresses, each.key, null)
   network_tier = lookup(var.internal_address_tiers, each.key, null)
+  purpose      = lookup(var.internal_address_purposes, each.key, null)
   # labels       = lookup(var.internal_address_labels, each.key, {})
 }

--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -39,8 +39,8 @@ resource "google_compute_address" "internal" {
   address_type = "INTERNAL"
   region       = each.value.region
   subnetwork   = each.value.subnetwork
-  address      = lookup(var.internal_address_addresses, each.key, null)
-  network_tier = lookup(var.internal_address_tiers, each.key, null)
-  purpose      = lookup(var.internal_address_purposes, each.key, null)
+  address      = try(var.internal_addresses_config[each.key].address, null)
+  network_tier = try(var.internal_addresses_config[each.key].tier, null)
+  purpose      = try(var.internal_addresses_config[each.key].purpose, null)
   # labels       = lookup(var.internal_address_labels, each.key, {})
 }

--- a/modules/net-address/outputs.tf
+++ b/modules/net-address/outputs.tf
@@ -31,7 +31,6 @@ output "global_addresses" {
     address.name => {
       address   = address.address
       self_link = address.self_link
-      status    = address.status
     }
   }
 }

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -47,6 +47,12 @@ variable "internal_address_addresses" {
   default     = {}
 }
 
+variable "internal_address_purposes" {
+  description = "Optional purpose for internal addresses, keyed by name."
+  type        = map(string)
+  default     = {}
+}
+
 variable "internal_address_tiers" {
   description = "Optional network tiers for internal addresses, keyed by name."
   type        = map(string)

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -16,4 +16,7 @@
 
 terraform {
   required_version = ">= 0.12.6"
+  required_providers {
+    google-beta = "~> 3.28.0"
+  }
 }

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -136,7 +136,7 @@ module "vpn_ha" {
 
 | name | description | type | required | default |
 |---|---|:---: |:---:|:---:|
-| name | VPN gateway name, and prefix used for dependent resources. | <code title="">string</code> | ✓ |  |
+| name | VPN Gateway name (if an existing VPN Gateway is not used), and prefix used for dependent resources. | <code title="">string</code> | ✓ |  |
 | network | VPC used for the gateway and routes. | <code title="">string</code> | ✓ |  |
 | project_id | Project where resources will be created. | <code title="">string</code> | ✓ |  |
 | region | Region used for resources. | <code title="">string</code> | ✓ |  |
@@ -146,16 +146,18 @@ module "vpn_ha" {
 | *router_advertise_config* | Router custom advertisement configuration, ip_ranges is a map of address ranges and descriptions. | <code title="object&#40;&#123;&#10;groups    &#61; list&#40;string&#41;&#10;ip_ranges &#61; map&#40;string&#41;&#10;mode      &#61; string&#10;&#125;&#41;">object({...})</code> |  | <code title="">null</code> |
 | *router_asn* | Router ASN used for auto-created router. | <code title="">number</code> |  | <code title="">64514</code> |
 | *router_create* | Create router. | <code title="">bool</code> |  | <code title="">true</code> |
-| *router_name* | Router name used for auto created router, or to specify existing router to use. Leave blank to use VPN name for auto created router. | <code title="">string</code> |  | <code title=""></code> |
+| *router_name* | Router name used for auto created router, or to specify an existing router to use if `router_create` is set to `true`. Leave blank to use VPN name for auto created router. | <code title="">string</code> |  | <code title=""></code> |
 | *tunnels* | VPN tunnel configurations, bgp_peer_options is usually null. | <code title="map&#40;object&#40;&#123;&#10;bgp_peer &#61; object&#40;&#123;&#10;address &#61; string&#10;asn     &#61; number&#10;&#125;&#41;&#10;bgp_peer_options &#61; object&#40;&#123;&#10;advertise_groups    &#61; list&#40;string&#41;&#10;advertise_ip_ranges &#61; map&#40;string&#41;&#10;advertise_mode      &#61; string&#10;route_priority      &#61; number&#10;&#125;&#41;&#10;bgp_session_range               &#61; string&#10;ike_version                     &#61; number&#10;vpn_gateway_interface           &#61; number&#10;peer_external_gateway_interface &#61; number&#10;shared_secret                   &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
+| *vpn_gateway* | HA VPN Gateway Self Link for using an existing HA VPN Gateway, leave empty if `vpn_gateway_create` is set to `true`. | <code title="">string</code> |  | <code title="">null</code> |
+| *vpn_gateway_create* | Create HA VPN Gateway. | <code title="">bool</code> |  | <code title="">true</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
 | external_gateway | External VPN gateway resource. |  |
-| gateway | HA VPN gateway resource. |  |
-| name | VPN gateway name. |  |
+| gateway | VPN gateway resource (only if auto-created). |  |
+| name | VPN gateway name (only if auto-created).  |  |
 | random_secret | Generated secret. | ✓ |
 | router | Router resource (only if auto-created). |  |
 | router_name | Router name. |  |

--- a/modules/net-vpn-ha/outputs.tf
+++ b/modules/net-vpn-ha/outputs.tf
@@ -1,4 +1,3 @@
-
 /**
  * Copyright 2019 Google LLC
  *
@@ -16,8 +15,12 @@
  */
 
 output "gateway" {
-  description = "HA VPN gateway resource."
-  value       = google_compute_ha_vpn_gateway.ha_gateway
+  description = "VPN gateway resource (only if auto-created)."
+  value = (
+    var.vpn_gateway_create
+    ? google_compute_ha_vpn_gateway.ha_gateway[0]
+    : null
+  )
 }
 
 output "external_gateway" {
@@ -30,13 +33,21 @@ output "external_gateway" {
 }
 
 output "name" {
-  description = "VPN gateway name."
-  value       = google_compute_ha_vpn_gateway.ha_gateway.name
+  description = "VPN gateway name (only if auto-created). "
+  value = (
+    var.vpn_gateway_create
+    ? google_compute_ha_vpn_gateway.ha_gateway[0].name
+    : null
+  )
 }
 
 output "router" {
   description = "Router resource (only if auto-created)."
-  value       = var.router_name == "" ? google_compute_router.router[0] : null
+  value = (
+    var.router_name == ""
+    ? google_compute_router.router[0]
+    : null
+  )
 }
 
 output "router_name" {
@@ -46,7 +57,7 @@ output "router_name" {
 
 output "self_link" {
   description = "HA VPN gateway self link."
-  value       = google_compute_ha_vpn_gateway.ha_gateway.self_link
+  value       = local.vpn_gateway
 }
 
 output "tunnels" {

--- a/modules/net-vpn-ha/variables.tf
+++ b/modules/net-vpn-ha/variables.tf
@@ -15,8 +15,20 @@
  */
 
 variable "name" {
-  description = "VPN gateway name, and prefix used for dependent resources."
+  description = "VPN Gateway name (if an existing VPN Gateway is not used), and prefix used for dependent resources."
   type        = string
+}
+
+variable "vpn_gateway_create" {
+  description = "Create HA VPN Gateway."
+  type        = bool
+  default     = true
+}
+
+variable "vpn_gateway" {
+  description = "HA VPN Gateway Self Link for using an existing HA VPN Gateway, leave empty if `vpn_gateway_create` is set to `true`."
+  type        = string
+  default     = null
 }
 
 variable "network" {
@@ -81,7 +93,7 @@ variable "router_create" {
 }
 
 variable "router_name" {
-  description = "Router name used for auto created router, or to specify existing router to use. Leave blank to use VPN name for auto created router."
+  description = "Router name used for auto created router, or to specify an existing router to use if `router_create` is set to `true`. Leave blank to use VPN name for auto created router."
   type        = string
   default     = ""
 }

--- a/tests/modules/net_address/__init__.py
+++ b/tests/modules/net_address/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/net_address/fixture/main.tf
+++ b/tests/modules/net_address/fixture/main.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source                    = "../../../../modules/net-address"
+  external_addresses        = var.external_addresses
+  global_addresses          = var.global_addresses
+  internal_addresses        = var.internal_addresses
+  internal_addresses_config = var.internal_addresses_config
+  project_id                = var.project_id
+}

--- a/tests/modules/net_address/fixture/outputs.tf
+++ b/tests/modules/net_address/fixture/outputs.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "module" {
+  value = module.test
+}

--- a/tests/modules/net_address/fixture/variables.tf
+++ b/tests/modules/net_address/fixture/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,16 @@
  */
 
 variable "external_addresses" {
-  description = "Map of external address regions, keyed by name."
-  type        = map(string)
-  default     = {}
+  type    = map(string)
+  default = {}
 }
 
-# variable "external_address_labels" {
-#   description = "Optional labels for external addresses, keyed by address name."
-#   type        = map(map(string))
-#   default     = {}
-# }
-
 variable "global_addresses" {
-  description = "List of global addresses to create."
-  type        = list(string)
-  default     = []
+  type    = list(string)
+  default = []
 }
 
 variable "internal_addresses" {
-  description = "Map of internal addresses to create, keyed by name."
   type = map(object({
     region     = string
     subnetwork = string
@@ -42,7 +33,6 @@ variable "internal_addresses" {
 }
 
 variable "internal_addresses_config" {
-  description = "Optional configuration for internal addresses, keyed by name. Unused options can be set to null."
   type = map(object({
     address = string
     purpose = string
@@ -51,13 +41,7 @@ variable "internal_addresses_config" {
   default = {}
 }
 
-# variable "internal_address_labels" {
-#   description = "Optional labels for internal addresses, keyed by address name."
-#   type        = map(map(string))
-#   default     = {}
-# }
-
 variable "project_id" {
-  description = "Project where the addresses will be created."
-  type        = string
+  type    = string
+  default = "my-project"
 }

--- a/tests/modules/net_address/test_plan.py
+++ b/tests/modules/net_address/test_plan.py
@@ -1,0 +1,70 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import pytest
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
+
+
+def test_external_addresses(plan_runner):
+  addresses = '{one = "europe-west1", two = "europe-west2"}'
+  _, resources = plan_runner(FIXTURES_DIR, external_addresses=addresses)
+  assert [r['values']['name'] for r in resources] == ['one', 'two']
+  assert set(r['values']['address_type']
+             for r in resources) == set(['EXTERNAL'])
+  assert [r['values']['region']
+          for r in resources] == ['europe-west1', 'europe-west2']
+
+
+def test_global_addresses(plan_runner):
+  _, resources = plan_runner(FIXTURES_DIR, global_addresses='["one", "two"]')
+  assert [r['values']['name'] for r in resources] == ['one', 'two']
+  assert set(r['values']['address_type'] for r in resources) == set([None])
+
+
+def test_internal_addresses(plan_runner):
+  addresses = (
+      '{one = {region = "europe-west1", subnetwork = "foobar"}, '
+      'two = {region = "europe-west2", subnetwork = "foobarz"}}'
+  )
+  _, resources = plan_runner(FIXTURES_DIR, internal_addresses=addresses)
+  assert [r['values']['name'] for r in resources] == ['one', 'two']
+  assert set(r['values']['address_type']
+             for r in resources) == set(['INTERNAL'])
+  assert [r['values']['region']
+          for r in resources] == ['europe-west1', 'europe-west2']
+
+
+def test_internal_addresses_config(plan_runner):
+  addresses = (
+      '{one = {region = "europe-west1", subnetwork = "foobar"}, '
+      'two = {region = "europe-west2", subnetwork = "foobarz"}}'
+  )
+  config = (
+      '{one = {address = "10.0.0.2", purpose = "SHARED_LOADBALANCER_VIP", '
+      'tier=null}}'
+  )
+  _, resources = plan_runner(FIXTURES_DIR,
+                             internal_addresses=addresses,
+                             internal_addresses_config=config)
+  assert [r['values']['name'] for r in resources] == ['one', 'two']
+  assert set(r['values']['address_type']
+             for r in resources) == set(['INTERNAL'])
+  assert [r['values'].get('address')
+          for r in resources] == ['10.0.0.2', None]
+  assert [r['values'].get('purpose')
+          for r in resources] == ['SHARED_LOADBALANCER_VIP', None]

--- a/tests/modules/net_vpc/test_plan_subnets.py
+++ b/tests/modules/net_vpc/test_plan_subnets.py
@@ -58,7 +58,9 @@ def test_subnet_log_configs(plan_runner):
   for r in resources:
     if r['type'] != 'google_compute_subnetwork':
       continue
-    flow_logs[r['values']['name']] = r['values']['log_config']
+    flow_logs[r['values']['name']] = [{key: config[key] for key in config.keys() 
+                               & {'aggregation_interval', 'flow_sampling', 'metadata'}} 
+                               for config in r['values']['log_config']]
   assert flow_logs == {
       # enable, override one default option
       'a': [{


### PR DESCRIPTION
This adds support for specifying internal address purposes, which is [only supported from version 3.28.0](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md#3280-june-29-2020) of the `google-beta` provider, so this requirement is also set in the module.

The module's interface has always been a bit ugly, and it's even uglier now that a new variable has been added. I would love breaking compatibility and putting all internal IP configuration options in a single `internal_address_config` variable. Upside is a cleaner interface more similar to other modules, downside is one needs to set all three configuration items (`null` can be used of course) even if a single one needs to be specified.

WDYT?