### PR TITLE
Change bucket_policy_only into uniform_bucket_level_access in GCS module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - add support for logging and better type for the `retention_policies` variable in `gcs` module
+- **incompatible change** deprecate bucket_policy_only in favor of uniform_bucket_level_access in `gcs` module
 
 ## [3.3.0] - 2020-09-01
 

--- a/modules/folders-unit/main.tf
+++ b/modules/folders-unit/main.tf
@@ -95,7 +95,7 @@ resource "google_storage_bucket" "tfstate" {
   location           = var.gcs_defaults.location
   storage_class      = var.gcs_defaults.storage_class
   force_destroy      = false
-  bucket_policy_only = true
+  uniform_bucket_level_access = true
   versioning {
     enabled = true
   }

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -90,7 +90,7 @@ module "buckets" {
 |---|---|:---: |:---:|:---:|
 | names | Bucket name suffixes. | <code title="list&#40;string&#41;">list(string)</code> | ✓ |  |
 | project_id | Bucket project id. | <code title="">string</code> | ✓ |  |
-| *bucket_policy_only* | Optional map to disable object ACLS keyed by name, defaults to true. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
+| *uniform_bucket_level_access* | Optional map to enable object ACLs keyed by name, defaults to true. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
 | *encryption_keys* | Per-bucket KMS keys that will be used for encryption. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *force_destroy* | Optional map to set force destroy keyed by name, defaults to false. | <code title="map&#40;bool&#41;">map(bool)</code> |  | <code title="">{}</code> |
 | *iam_members* | IAM members keyed by bucket name and role. | <code title="map&#40;map&#40;list&#40;string&#41;&#41;&#41;">map(map(list(string)))</code> |  | <code title="">{}</code> |

--- a/modules/gcs/main.tf
+++ b/modules/gcs/main.tf
@@ -54,7 +54,7 @@ resource "google_storage_bucket" "buckets" {
   location           = var.location
   storage_class      = var.storage_class
   force_destroy      = lookup(var.force_destroy, each.key, false)
-  bucket_policy_only = lookup(var.bucket_policy_only, each.key, true)
+  uniform_bucket_level_access = lookup(var.uniform_bucket_level_access, each.key, true)
   versioning {
     enabled = lookup(var.versioning, each.key, false)
   }

--- a/modules/gcs/variables.tf
+++ b/modules/gcs/variables.tf
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-variable "bucket_policy_only" {
-  description = "Optional map to disable object ACLS keyed by name, defaults to true."
+variable "uniform_bucket_level_access" {
+  description = "Optional map to allow using object ACLs (false) or not (true, this is the recommended behavior) , defaults to true (which is the recommended practice, but not the behavior of storage API)."
   type        = map(bool)
   default     = {}
 }

--- a/tests/modules/gcs/fixture/main.tf
+++ b/tests/modules/gcs/fixture/main.tf
@@ -17,7 +17,7 @@
 module "test" {
   source             = "../../../../modules/gcs"
   project_id         = "my-project"
-  bucket_policy_only = var.bucket_policy_only
+  uniform_bucket_level_access = var.uniform_bucket_level_access
   force_destroy      = var.force_destroy
   iam_members        = var.iam_members
   iam_roles          = var.iam_roles

--- a/tests/modules/gcs/fixture/variables.tf
+++ b/tests/modules/gcs/fixture/variables.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-variable "bucket_policy_only" {
+variable "uniform_bucket_level_access" {
   type    = map(bool)
   default = { bucket-a = false }
 }

--- a/tests/modules/gcs/test_plan.py
+++ b/tests/modules/gcs/test_plan.py
@@ -44,7 +44,7 @@ def test_prefix(plan_runner):
 def test_map_values(plan_runner):
   "Test that map values set the correct attributes on buckets."
   _, resources = plan_runner(FIXTURES_DIR)
-  bpo = dict((r['values']['name'], r['values']['bucket_policy_only'])
+  bpo = dict((r['values']['name'], r['values']['uniform_bucket_level_access'])
              for r in resources)
   assert bpo == {'bucket-a': False, 'bucket-b': True}
   force_destroy = dict((r['values']['name'], r['values']['force_destroy'])


### PR DESCRIPTION
This PR is to reflect the deprecation of bucket_policy_only in favor of uniform_bucket_level_access in the terraform provider (https://github.com/hashicorp/terraform-provider-google/releases/tag/v3.38.0).

To stay consistent with the default behavior of the module, the default for uniform_bucket_level_access is set to `true` to override the default in storage API which is `false`.
I thought it was wise, but I could be wrong.
