### PR TITLE
provider version update

### DIFF
--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 0.12.6"
   required_providers {
-    google-beta = "~> 3.28.0"
+    google-beta = "~> 3.40.0"
   }
 }


### PR DESCRIPTION
google-beta provider version 3.28.0 can no more be fetched by Terraform, updated the version to latest