### PR TITLE
Parallel tests

### DIFF
--- a/.ci/cloudbuild.test.examples.yaml
+++ b/.ci/cloudbuild.test.examples.yaml
@@ -43,3 +43,6 @@ substitutions:
 tags:
   - "ci"
   - "test"
+
+options:
+ machineType: 'N1_HIGHCPU_8'

--- a/.ci/cloudbuild.test.examples.yaml
+++ b/.ci/cloudbuild.test.examples.yaml
@@ -31,6 +31,7 @@ steps:
     entrypoint: pytest
     args:
       - -vv
+      - --numprocesses=8
       - tests/modules/examples
     env:
       - PATH=/usr/local/bin:/usr/bin:/bin:/builder/home/.local/bin

--- a/.ci/cloudbuild.test.yaml
+++ b/.ci/cloudbuild.test.yaml
@@ -57,3 +57,6 @@ substitutions:
 tags:
   - "ci"
   - "test"
+
+options:
+ machineType: 'N1_HIGHCPU_8'

--- a/.ci/cloudbuild.test.yaml
+++ b/.ci/cloudbuild.test.yaml
@@ -31,8 +31,8 @@ steps:
     entrypoint: pytest
     args:
       - -vv
-      - --ignore
-      - tests/modules/examples
+      - --ignore=tests/modules/examples
+      - --numprocesses=8
       - tests/modules
     env:
       - PATH=/usr/local/bin:/usr/bin:/bin:/builder/home/.local/bin
@@ -42,6 +42,7 @@ steps:
     entrypoint: pytest
     args:
       - -vv
+      - --numprocesses=8
       - tests/cloud_operations
       - tests/data_solutions
       - tests/foundations

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=4.6.0
+pytest-xdist>=2.1.0
 PyYAML>=5.3
 tftest>=1.5.2
 marko>=0.9.1


### PR DESCRIPTION
This PR changes the fixtures that run terraform to copy the fixture contents to a temporary directory before running init. This way we can run terraform tests in parallel avoiding lock conflicts. 