### PR TITLE
Adding node taints on gke nodepool

### DIFF
--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -54,7 +54,6 @@ module "cluster-1-nodepool-1" {
 | *node_guest_accelerator* | Map of type and count of attached accelerator cards. | <code title="map&#40;number&#41;">map(number)</code> |  | <code title="">{}</code> |
 | *node_image_type* | Nodes image type. | <code title="">string</code> |  | <code title="">null</code> |
 | *node_labels* | Kubernetes labels attached to nodes. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
-| *node_taints* | Kubernetes taints attached to nodes. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *node_local_ssd_count* | Number of local SSDs attached to nodes. | <code title="">number</code> |  | <code title="">0</code> |
 | *node_locations* | Optional list of zones in which nodes should be located. Uses cluster locations if unset. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">null</code> |
 | *node_machine_type* | Nodes machine type. | <code title="">string</code> |  | <code title="">n1-standard-1</code> |
@@ -67,6 +66,7 @@ module "cluster-1-nodepool-1" {
 | *node_service_account_scopes* | Scopes applied to service account. Default to: 'cloud-platform' when creating a service account; 'devstorage.read_only', 'logging.write', 'monitoring.write' otherwise. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *node_shielded_instance_config* | Shielded instance options. | <code title="object&#40;&#123;&#10;enable_secure_boot          &#61; bool&#10;enable_integrity_monitoring &#61; bool&#10;&#125;&#41;">object({...})</code> |  | <code title="">null</code> |
 | *node_tags* | Network tags applied to nodes. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">null</code> |
+| *node_taints* | Kubernetes taints applied to nodes. E.g. type=blue:NoSchedule | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *upgrade_config* | Optional node upgrade configuration. | <code title="object&#40;&#123;&#10;max_surge       &#61; number&#10;max_unavailable &#61; number&#10;&#125;&#41;">object({...})</code> |  | <code title="">null</code> |
 | *workload_metadata_config* | Metadata configuration to expose to workloads on the node pool. | <code title="">string</code> |  | <code title="">GKE_METADATA_SERVER</code> |
 

--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -54,6 +54,7 @@ module "cluster-1-nodepool-1" {
 | *node_guest_accelerator* | Map of type and count of attached accelerator cards. | <code title="map&#40;number&#41;">map(number)</code> |  | <code title="">{}</code> |
 | *node_image_type* | Nodes image type. | <code title="">string</code> |  | <code title="">null</code> |
 | *node_labels* | Kubernetes labels attached to nodes. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
+| *node_taints* | Kubernetes taints attached to nodes. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *node_local_ssd_count* | Number of local SSDs attached to nodes. | <code title="">number</code> |  | <code title="">0</code> |
 | *node_locations* | Optional list of zones in which nodes should be located. Uses cluster locations if unset. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">null</code> |
 | *node_machine_type* | Nodes machine type. | <code title="">string</code> |  | <code title="">n1-standard-1</code> |

--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -37,6 +37,20 @@ locals {
       ]
     )
   )
+  node_taint_effect = {
+    "NoExecute"        = "NO_EXECUTE",
+    "NoSchedule"       = "NO_SCHEDULE"
+    "PreferNoSchedule" = "PREFER_NO_SCHEDULE"
+  }
+  temp_node_pools_taints = [
+    for taint in var.node_taints :
+    {
+      "key"    = element(split("=", taint), 0),
+      "value"  = element(split(":", element(split("=", taint), 1)), 0),
+      "effect" = lookup(local.node_taint_effect, element(split(":", taint), 1)),
+    }
+  ]
+  node_taints = local.temp_node_pools_taints
 }
 
 resource "google_service_account" "service_account" {
@@ -65,6 +79,7 @@ resource "google_container_node_pool" "nodepool" {
     disk_type        = var.node_disk_type
     image_type       = var.node_image_type
     labels           = var.node_labels
+    taint            = local.node_taints
     local_ssd_count  = var.node_local_ssd_count
     machine_type     = var.node_machine_type
     metadata         = var.node_metadata

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -96,6 +96,12 @@ variable "node_labels" {
   default     = {}
 }
 
+variable "node_taints" {
+  description = "Kubernetes taints applied to nodes. E.g. type=blue:NoSchedule"
+  type        = list(string)
+  default     = []
+}
+
 variable "node_local_ssd_count" {
   description = "Number of local SSDs attached to nodes."
   type        = number
@@ -166,12 +172,6 @@ variable "node_tags" {
   type        = list(string)
   default     = null
 }
-
-# variable "node_taint" {
-#   description = "Kubernetes taints applied to nodes."
-#   type        = string
-#   default     = null
-# }
 
 variable "node_count" {
   description = "Number of nodes per instance group, can be updated after creation. Ignored when autoscaling is set."


### PR DESCRIPTION
This PR addresses the need to have working taints on gke nodepools.

Automatic transformation via local variables from list(string) to the map google provider expects.

Example usage:

```hcl
node_taints = [
    "sighup.io/role=app:NoSchedule"
  ]
```