### PR TITLE
Add boot_disk_kms_key to node_config

### DIFF
--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -48,6 +48,7 @@ module "cluster-1-nodepool-1" {
 | *management_config* | Optional node management configuration. | <code title="object&#40;&#123;&#10;auto_repair  &#61; bool&#10;auto_upgrade &#61; bool&#10;&#125;&#41;">object({...})</code> |  | <code title="">null</code> |
 | *max_pods_per_node* | Maximum number of pods per node. | <code title="">number</code> |  | <code title="">null</code> |
 | *name* | Optional nodepool name. | <code title="">string</code> |  | <code title="">null</code> |
+| *node_boot_disk_kms_key* | Customer Managed Encryption Key used to encrypt the boot disk attached to each node | <code title="">string</code> |  | <code title="">null</code> |
 | *node_count* | Number of nodes per instance group, can be updated after creation. Ignored when autoscaling is set. | <code title="">number</code> |  | <code title="">null</code> |
 | *node_disk_size* | Node disk size, defaults to 100GB. | <code title="">number</code> |  | <code title="">100</code> |
 | *node_disk_type* | Node disk type, defaults to pd-standard. | <code title="">string</code> |  | <code title="">pd-standard</code> |
@@ -59,7 +60,6 @@ module "cluster-1-nodepool-1" {
 | *node_machine_type* | Nodes machine type. | <code title="">string</code> |  | <code title="">n1-standard-1</code> |
 | *node_metadata* | Metadata key/value pairs assigned to nodes. Set disable-legacy-endpoints to true when using this variable. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">null</code> |
 | *node_min_cpu_platform* | Minimum CPU platform for nodes. | <code title="">string</code> |  | <code title="">null</code> |
-| *node_node_boot_disk_kms_key* | Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool | <code title="">string</code> |  | <code title="">null</code> |
 | *node_preemptible* | Use preemptible VMs for nodes. | <code title="">bool</code> |  | <code title="">null</code> |
 | *node_sandbox_config* | GKE Sandbox configuration. Needs image_type set to COS_CONTAINERD and node_version set to 1.12.7-gke.17 when using this variable. | <code title="">string</code> |  | <code title="">null</code> |
 | *node_service_account* | Service account email. Unused if service account is auto-created. | <code title="">string</code> |  | <code title="">null</code> |

--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -59,6 +59,7 @@ module "cluster-1-nodepool-1" {
 | *node_machine_type* | Nodes machine type. | <code title="">string</code> |  | <code title="">n1-standard-1</code> |
 | *node_metadata* | Metadata key/value pairs assigned to nodes. Set disable-legacy-endpoints to true when using this variable. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">null</code> |
 | *node_min_cpu_platform* | Minimum CPU platform for nodes. | <code title="">string</code> |  | <code title="">null</code> |
+| *node_node_boot_disk_kms_key* | Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool | <code title="">string</code> |  | <code title="">null</code> |
 | *node_preemptible* | Use preemptible VMs for nodes. | <code title="">bool</code> |  | <code title="">null</code> |
 | *node_sandbox_config* | GKE Sandbox configuration. Needs image_type set to COS_CONTAINERD and node_version set to 1.12.7-gke.17 when using this variable. | <code title="">string</code> |  | <code title="">null</code> |
 | *node_service_account* | Service account email. Unused if service account is auto-created. | <code title="">string</code> |  | <code title="">null</code> |

--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -75,19 +75,20 @@ resource "google_container_node_pool" "nodepool" {
   version            = var.gke_version
 
   node_config {
-    disk_size_gb     = var.node_disk_size
-    disk_type        = var.node_disk_type
-    image_type       = var.node_image_type
-    labels           = var.node_labels
-    taint            = local.node_taints
-    local_ssd_count  = var.node_local_ssd_count
-    machine_type     = var.node_machine_type
-    metadata         = var.node_metadata
-    min_cpu_platform = var.node_min_cpu_platform
-    oauth_scopes     = local.service_account_scopes
-    preemptible      = var.node_preemptible
-    service_account  = local.service_account_email
-    tags             = var.node_tags
+    disk_size_gb      = var.node_disk_size
+    disk_type         = var.node_disk_type
+    image_type        = var.node_image_type
+    labels            = var.node_labels
+    taint             = local.node_taints
+    local_ssd_count   = var.node_local_ssd_count
+    machine_type      = var.node_machine_type
+    metadata          = var.node_metadata
+    min_cpu_platform  = var.node_min_cpu_platform
+    oauth_scopes      = local.service_account_scopes
+    preemptible       = var.node_preemptible
+    service_account   = local.service_account_email
+    tags              = var.node_tags
+    boot_disk_kms_key = var.node_boot_disk_kms_key
 
     dynamic guest_accelerator {
       for_each = var.node_guest_accelerator

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -66,7 +66,7 @@ variable "name" {
   default     = null
 }
 
-variable "node_node_boot_disk_kms_key" {
+variable "node_boot_disk_kms_key" {
   description = "Customer Managed Encryption Key used to encrypt the boot disk attached to each node"
   type        = string
   default     = null

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -66,6 +66,12 @@ variable "name" {
   default     = null
 }
 
+variable "node_node_boot_disk_kms_key" {
+  description = "Customer Managed Encryption Key used to encrypt the boot disk attached to each node"
+  type        = string
+  default     = null
+}
+
 variable "node_disk_size" {
   description = "Node disk size, defaults to 100GB."
   type        = number


### PR DESCRIPTION
Add the possibility to use a Customer Managed Encryption Key to encrypt the boot disk attached to each node in the node pool.

Node config reference: 
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#node_config

Cloud KMS reference: 
https://cloud.google.com/compute/docs/disks/customer-managed-encryption