### PR TITLE
Added support for forwarding path attribute in Cloud DNS

### DIFF
--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -34,7 +34,7 @@ module "private-dns" {
 | *default_key_specs_zone* | DNSSEC default zone signing specifications: algorithm, key_length, key_type, kind. | <code title="">any</code> |  | <code title="">{}</code> |
 | *description* | Domain description. | <code title="">string</code> |  | <code title="">Terraform managed.</code> |
 | *dnssec_config* | DNSSEC configuration: kind, non_existence, state. | <code title="">any</code> |  | <code title="">{}</code> |
-| *forwarders* | List of target name servers, only valid for 'forwarding' zone types. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
+| *forwarders* | List of target name servers objects, only valid for 'forwarding' zone types. | <code title="list&#40;string&#41;">list(object({...}))</code> |  | <code title="">[]</code> |
 | *peer_network* | Peering network self link, only valid for 'peering' zone types. | <code title="">string</code> |  | <code title="">null</code> |
 | *recordsets* | List of DNS record objects to manage. | <code title="list&#40;object&#40;&#123;&#10;name    &#61; string&#10;type &#61; string&#10;ttl     &#61; number&#10;records &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list(object({...}))</code> |  | <code title="">[]</code> |
 | *service_directory_namespace* | Service directory namespace id (URL), only valid for 'service-directory' zone types. | <code title="">string</code> |  | <code title="">null</code> |

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -48,10 +48,11 @@ resource "google_dns_managed_zone" "non-public" {
     )
     content {
       dynamic "target_name_servers" {
-        for_each = var.forwarders
-        iterator = address
+        for_each = { for target_server in var.forwarders : target_server.ipv4_address => target_server.forwarding_path }
+        iterator = target_server
         content {
-          ipv4_address = address.value
+          ipv4_address    = target_server.key
+          forwarding_path = target_server.value
         }
       }
     }

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -53,10 +53,9 @@ variable "domain" {
   type        = string
 }
 
-# TODO(ludoo): add support for forwarding path attribute
 variable "forwarders" {
   description = "List of target name servers, only valid for 'forwarding' zone types."
-  type        = list(string)
+  type        = list(object({ ipv4_address = string, forwarding_path = string }))
   default     = []
 }
 


### PR DESCRIPTION
I updated the target server ipv4 list to a list of objects (with `ipv4_address` and `forwarding_path` attributes).

Example of usage:

```
forwarders = [
    {
      ipv4_address    = "10.103.195.124"
      forwarding_path = "private"
    },
   {
      ipv4_address    = "10.236.195.230"
      forwarding_path = "default"
    }
]
```