### PR TITLE
Changed parent folder from root_node to shared-folder into the audit-project example code.

### DIFF
--- a/foundations/business-units/main.tf
+++ b/foundations/business-units/main.tf
@@ -108,7 +108,7 @@ module "bu-machine-learning" {
 module "audit-project" {
   source          = "../../modules/project"
   name            = "audit"
-  parent          = var.root_node
+  parent          = module.shared-folder.id
   prefix          = var.prefix
   billing_account = var.billing_account_id
   iam = {


### PR DESCRIPTION
Fix for the parent folder of the audit-project. it was set to root-node instead of shared-folder as indicated into the overview diagram.