### PR TITLE
Update squid cos container

### DIFF
--- a/modules/cloud-config-container/squid/README.md
+++ b/modules/cloud-config-container/squid/README.md
@@ -8,7 +8,7 @@ The resulting `cloud-config` can be customized in a number of ways:
 - additional files (e.g. additional acls) can be passed in via the `files` variable
 - a completely custom `cloud-config` can be passed in via the `cloud_config` variable, and additional template variables can be passed in via `config_variables`
 
-The default instance configuration inserts iptables rules to allow traffic on TCP port 3128.
+The default instance configuration inserts iptables rules to allow traffic on TCP port 3128. With the default `squid.conf`, deny rules take precedence over allow rules.
 
 Logging and monitoring are enabled via the [Google Cloud Logging driver](https://docs.docker.com/config/containers/logging/gcplogs/) configured for the Squid container, and the [Node Problem Detector](https://cloud.google.com/container-optimized-os/docs/how-to/monitoring) service started by default on boot.
 
@@ -61,15 +61,17 @@ module "cos-squid" {
 
 | name | description | type | required | default |
 |---|---|:---: |:---:|:---:|
-| *clients* | List of CIDRs from which Squid will allow connections | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
+| *allow* | List of domains Squid will allow connections to. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
+| *clients* | List of CIDR ranges from which Squid will allow connections. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *cloud_config* | Cloud config template path. If null default will be used. | <code title="">string</code> |  | <code title="">null</code> |
 | *config_variables* | Additional variables used to render the cloud-config and Squid templates. | <code title="map&#40;any&#41;">map(any)</code> |  | <code title="">{}</code> |
+| *default_action* | Default action for domains not matching neither the allow or deny lists | <code title="">string</code> |  | <code title="deny&#10;validation &#123;&#10;condition     &#61; var.default_action &#61;&#61; &#34;deny&#34; &#124;&#124; var.default_action &#61;&#61; &#34;allow&#34;&#10;error_message &#61; &#34;Default action must be allow or deny.&#34;&#10;&#125;">...</code> |
+| *deny* | List of domains Squid will deny connections to. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 | *file_defaults* | Default owner and permissions for files. | <code title="object&#40;&#123;&#10;owner       &#61; string&#10;permissions &#61; string&#10;&#125;&#41;">object({...})</code> |  | <code title="&#123;&#10;owner       &#61; &#34;root&#34;&#10;permissions &#61; &#34;0644&#34;&#10;&#125;">...</code> |
 | *files* | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;content     &#61; string&#10;owner       &#61; string&#10;permissions &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 | *squid_config* | Squid configuration path, if null default will be used. | <code title="">string</code> |  | <code title="">null</code> |
 | *test_instance* | Test/development instance attributes, leave null to skip creation. | <code title="object&#40;&#123;&#10;project_id &#61; string&#10;zone       &#61; string&#10;name       &#61; string&#10;type &#61; string&#10;network    &#61; string&#10;subnetwork &#61; string&#10;&#125;&#41;">object({...})</code> |  | <code title="">null</code> |
 | *test_instance_defaults* | Test/development instance defaults used for optional configuration. If image is null, COS stable will be used. | <code title="object&#40;&#123;&#10;disks &#61; map&#40;object&#40;&#123;&#10;read_only &#61; bool&#10;size      &#61; number&#10;&#125;&#41;&#41;&#10;image                 &#61; string&#10;metadata              &#61; map&#40;string&#41;&#10;nat                   &#61; bool&#10;service_account_roles &#61; list&#40;string&#41;&#10;tags                  &#61; list&#40;string&#41;&#10;&#125;&#41;">object({...})</code> |  | <code title="&#123;&#10;disks    &#61; &#123;&#125;&#10;image    &#61; null&#10;metadata &#61; &#123;&#125;&#10;nat      &#61; false&#10;service_account_roles &#61; &#91;&#10;&#34;roles&#47;logging.logWriter&#34;,&#10;&#34;roles&#47;monitoring.metricWriter&#34;&#10;&#93;&#10;tags &#61; &#91;&#34;ssh&#34;&#93;&#10;&#125;">...</code> |
-| *whitelist* | List of domains Squid will allow connections to | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |
 
 ## Outputs
 

--- a/modules/cloud-config-container/squid/cloud-config.yaml
+++ b/modules/cloud-config-container/squid/cloud-config.yaml
@@ -39,11 +39,17 @@ write_files:
     content: |
       ${indent(6, squid_config)}
 
-  - path: /etc/squid/whitelist.txt
+  - path: /etc/squid/allowlist.txt
     permissions: 0644
     owner: root
     content: |
-      ${indent(6, join("\n", whitelist))}
+      ${indent(6, join("\n", allow))}
+
+  - path: /etc/squid/denylist.txt
+    permissions: 0644
+    owner: root
+    content: |
+      ${indent(6, join("\n", deny))}
 
   - path: /etc/squid/clients.txt
     permissions: 0644

--- a/modules/cloud-config-container/squid/docker/Dockerfile
+++ b/modules/cloud-config-container/squid/docker/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:buster-slim
+
+ENV SQUID_VERSION=4.6 \
+    SQUID_CACHE_DIR=/var/spool/squid \
+    SQUID_LOG_DIR=/var/log/squid \
+    SQUID_USER=proxy
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y squid=${SQUID_VERSION}* \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /sbin/entrypoint.sh
+RUN chmod 755 /sbin/entrypoint.sh
+
+EXPOSE 3128/tcp
+ENTRYPOINT ["/sbin/entrypoint.sh"]

--- a/modules/cloud-config-container/squid/docker/cloudbuild.yaml
+++ b/modules/cloud-config-container/squid/docker/cloudbuild.yaml
@@ -1,0 +1,31 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit .
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - --tag=gcr.io/$PROJECT_ID/squid:${_IMAGE_VERSION}
+  - --tag=gcr.io/$PROJECT_ID/squid:latest
+  - .
+
+substitutions:
+    _IMAGE_VERSION: "20210215"
+images:
+  - 'gcr.io/$PROJECT_ID/squid:${_IMAGE_VERSION}'
+  - 'gcr.io/$PROJECT_ID/squid:latest'

--- a/modules/cloud-config-container/squid/docker/entrypoint.sh
+++ b/modules/cloud-config-container/squid/docker/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This container is based off Sameer Naik's existing squid container.
+# https://github.com/sameersbn/docker-squid
+
+set -e
+
+create_log_dir() {
+  mkdir -p ${SQUID_LOG_DIR}
+  chmod -R 755 ${SQUID_LOG_DIR}
+  chown -R ${SQUID_USER}:${SQUID_USER} ${SQUID_LOG_DIR}
+}
+
+create_cache_dir() {
+  mkdir -p ${SQUID_CACHE_DIR}
+  chown -R ${SQUID_USER}:${SQUID_USER} ${SQUID_CACHE_DIR}
+}
+
+create_log_dir
+create_cache_dir
+
+# allow arguments to be passed to squid
+if [[ ${1:0:1} = '-' ]]; then
+  EXTRA_ARGS="$@"
+  set --
+elif [[ ${1} == squid || ${1} == $(which squid) ]]; then
+  EXTRA_ARGS="${@:2}"
+  set --
+fi
+
+# default behaviour is to launch squid
+if [[ -z ${1} ]]; then
+  if [[ ! -d ${SQUID_CACHE_DIR}/00 ]]; then
+    echo "Initializing cache..."
+    $(which squid) -N -f /etc/squid/squid.conf -z
+  fi
+  echo "Starting squid..."
+  exec $(which squid) -f /etc/squid/squid.conf -NYCd 1 ${EXTRA_ARGS}
+else
+  exec "$@"
+fi

--- a/modules/cloud-config-container/squid/main.tf
+++ b/modules/cloud-config-container/squid/main.tf
@@ -39,7 +39,9 @@ locals {
     : var.cloud_config
   )
   config_variables = merge(var.config_variables, {
-    whitelist = var.whitelist
-    clients   = var.clients
+    allow          = var.allow
+    deny           = var.deny
+    clients        = var.clients
+    default_action = var.default_action
   })
 }

--- a/modules/cloud-config-container/squid/squid.conf
+++ b/modules/cloud-config-container/squid/squid.conf
@@ -8,12 +8,16 @@ acl ssl_ports port 443
 acl safe_ports port 80
 acl safe_ports port 443
 acl CONNECT method CONNECT
+acl to_metadata dst 169.254.169.254
 
-# read clientd cidr from clients.txt
+# read client CIDR ranges from clients.txt
 acl clients src "/etc/squid/clients.txt"
 
-# read whitelisted domains from whitelist.txt
-acl whitelist dstdomain "/etc/squid/whitelist.txt"
+# read allowed domains from allowlist.txt
+acl allowlist dstdomain "/etc/squid/allowlist.txt"
+
+# read denied domains from denylist.txt
+acl denylist dstdomain "/etc/squid/denylist.txt"
 
 # deny access to anything other than ports 80 and 443
 http_access deny !safe_ports
@@ -24,11 +28,17 @@ http_access deny CONNECT !ssl_ports
 # deny acccess to cachemgr
 http_access deny manager
 
-# deny access to localhost though the proxy
+# deny access to localhost through the proxy
 http_access deny to_localhost
 
-# allow connection from allowed clients only to the whitelisted domains
-http_access allow clients whitelist
+# deny access to the local metadata server through the proxy
+http_access deny to_metadata
+
+# deny connection from allowed clients to any denied domains
+http_access deny clients denylist
+
+# allow connection from allowed clients only to the allowed domains
+http_access allow clients allowlist
 
 # deny everything else
-http_access deny all
+http_access ${default_action} all

--- a/modules/cloud-config-container/squid/variables.tf
+++ b/modules/cloud-config-container/squid/variables.tf
@@ -54,14 +54,30 @@ variable "files" {
   default = {}
 }
 
-variable "whitelist" {
-  description = "List of domains Squid will allow connections to"
+variable "allow" {
+  description = "List of domains Squid will allow connections to."
+  type        = list(string)
+  default     = []
+}
+
+variable "deny" {
+  description = "List of domains Squid will deny connections to."
   type        = list(string)
   default     = []
 }
 
 variable "clients" {
-  description = "List of CIDRs from which Squid will allow connections"
+  description = "List of CIDR ranges from which Squid will allow connections."
   type        = list(string)
   default     = []
+}
+
+variable "default_action" {
+  description = "Default action for domains not matching neither the allow or deny lists"
+  type        = string
+  default     = "deny"
+  validation {
+    condition     = var.default_action == "deny" || var.default_action == "allow"
+    error_message = "Default action must be allow or deny."
+  }
 }


### PR DESCRIPTION
This PR
- Includes Dockerfile for the squid container used by `modules/cloud-config-container/squid/`
- Updates `modules/cloud-config-container/squid/` to support both allow lists and deny lists.