### PR TITLE
Add support for per-tunnel routers to VPN dynamic and HA

### DIFF
--- a/modules/net-vpn-dynamic/README.md
+++ b/modules/net-vpn-dynamic/README.md
@@ -23,6 +23,7 @@ module "vpn-dynamic" {
       bgp_session_range = "169.254.139.133/30"
       ike_version       = 2
       peer_ip           = "1.1.1.1"
+      router            = null
       shared_secret     = null
       bgp_peer_options = {
         advertise_groups = ["ALL_SUBNETS"]
@@ -54,7 +55,7 @@ module "vpn-dynamic" {
 | *router_asn* | Router ASN used for auto-created router. | <code title="">number</code> |  | <code title="">64514</code> |
 | *router_create* | Create router. | <code title="">bool</code> |  | <code title="">true</code> |
 | *router_name* | Router name used for auto created router, or to specify existing router to use. Leave blank to use VPN name for auto created router. | <code title="">string</code> |  | <code title=""></code> |
-| *tunnels* | VPN tunnel configurations, bgp_peer_options is usually null. | <code title="map&#40;object&#40;&#123;&#10;bgp_peer &#61; object&#40;&#123;&#10;address &#61; string&#10;asn     &#61; number&#10;&#125;&#41;&#10;bgp_peer_options &#61; object&#40;&#123;&#10;advertise_groups    &#61; list&#40;string&#41;&#10;advertise_ip_ranges &#61; map&#40;string&#41;&#10;advertise_mode      &#61; string&#10;route_priority      &#61; number&#10;&#125;&#41;&#10;bgp_session_range &#61; string&#10;ike_version       &#61; number&#10;peer_ip           &#61; string&#10;shared_secret     &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
+| *tunnels* | VPN tunnel configurations, bgp_peer_options is usually null. | <code title="map&#40;object&#40;&#123;&#10;bgp_peer &#61; object&#40;&#123;&#10;address &#61; string&#10;asn     &#61; number&#10;&#125;&#41;&#10;bgp_peer_options &#61; object&#40;&#123;&#10;advertise_groups    &#61; list&#40;string&#41;&#10;advertise_ip_ranges &#61; map&#40;string&#41;&#10;advertise_mode      &#61; string&#10;route_priority      &#61; number&#10;&#125;&#41;&#10;bgp_session_range &#61; string&#10;ike_version       &#61; number&#10;peer_ip           &#61; string&#10;router            &#61; string&#10;shared_secret     &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 
 ## Outputs
 

--- a/modules/net-vpn-dynamic/variables.tf
+++ b/modules/net-vpn-dynamic/variables.tf
@@ -98,6 +98,7 @@ variable "tunnels" {
     bgp_session_range = string
     ike_version       = number
     peer_ip           = string
+    router            = string
     shared_secret     = string
   }))
   default = {}

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -1,5 +1,5 @@
 # Cloud VPN HA Module
-This module makes it easy to deploy either GCP-to-GCP or GCP-to-On-prem [Cloud HA VPN](https://cloud.google.com/vpn/docs/concepts/overview#ha-vpn). 
+This module makes it easy to deploy either GCP-to-GCP or GCP-to-On-prem [Cloud HA VPN](https://cloud.google.com/vpn/docs/concepts/overview#ha-vpn).
 
 ## Examples
 
@@ -29,9 +29,10 @@ module "vpn_ha-1" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.1.2/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 0
       peer_external_gateway_interface = null
+      router                          = null
       shared_secret                   = ""
+      vpn_gateway_interface           = 0
     }
     remote-1 = {
       bgp_peer = {
@@ -41,9 +42,10 @@ module "vpn_ha-1" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.2.2/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 1
       peer_external_gateway_interface = null
+      router                          = null
       shared_secret                   = ""
+      vpn_gateway_interface           = 1
     }
   }
 }
@@ -65,9 +67,10 @@ module "vpn_ha-2" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.1.1/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 0
       peer_external_gateway_interface = null
+      router                          = null
       shared_secret                   = module.vpn_ha-1.random_secret
+      vpn_gateway_interface           = 0
     }
     remote-1 = {
       bgp_peer = {
@@ -77,14 +80,16 @@ module "vpn_ha-2" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.2.1/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 1
       peer_external_gateway_interface = null
+      router                          = null
       shared_secret                   = module.vpn_ha-1.random_secret
+      vpn_gateway_interface           = 1
     }
   }
 }
 # tftest:modules=2:resources=18
 ```
+
 ### GCP to on-prem
 
 ```hcl
@@ -111,9 +116,10 @@ module "vpn_ha" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.1.2/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 0
       peer_external_gateway_interface = 0
+      router                          = null
       shared_secret                   = "mySecret"
+      vpn_gateway_interface           = 0
     }
     remote-1 = {
       bgp_peer = {
@@ -123,9 +129,10 @@ module "vpn_ha" {
       bgp_peer_options                = null
       bgp_session_range               = "169.254.2.2/30"
       ike_version                     = 2
-      vpn_gateway_interface           = 1
       peer_external_gateway_interface = 0
+      router                          = null
       shared_secret                   = "mySecret"
+      vpn_gateway_interface           = 1
     }
   }
 }
@@ -148,7 +155,7 @@ module "vpn_ha" {
 | *router_asn* | Router ASN used for auto-created router. | <code title="">number</code> |  | <code title="">64514</code> |
 | *router_create* | Create router. | <code title="">bool</code> |  | <code title="">true</code> |
 | *router_name* | Router name used for auto created router, or to specify an existing router to use if `router_create` is set to `true`. Leave blank to use VPN name for auto created router. | <code title="">string</code> |  | <code title=""></code> |
-| *tunnels* | VPN tunnel configurations, bgp_peer_options is usually null. | <code title="map&#40;object&#40;&#123;&#10;bgp_peer &#61; object&#40;&#123;&#10;address &#61; string&#10;asn     &#61; number&#10;&#125;&#41;&#10;bgp_peer_options &#61; object&#40;&#123;&#10;advertise_groups    &#61; list&#40;string&#41;&#10;advertise_ip_ranges &#61; map&#40;string&#41;&#10;advertise_mode      &#61; string&#10;route_priority      &#61; number&#10;&#125;&#41;&#10;bgp_session_range               &#61; string&#10;ike_version                     &#61; number&#10;vpn_gateway_interface           &#61; number&#10;peer_external_gateway_interface &#61; number&#10;shared_secret                   &#61; string&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
+| *tunnels* | VPN tunnel configurations, bgp_peer_options is usually null. | <code title="map&#40;object&#40;&#123;&#10;bgp_peer &#61; object&#40;&#123;&#10;address &#61; string&#10;asn     &#61; number&#10;&#125;&#41;&#10;bgp_peer_options &#61; object&#40;&#123;&#10;advertise_groups    &#61; list&#40;string&#41;&#10;advertise_ip_ranges &#61; map&#40;string&#41;&#10;advertise_mode      &#61; string&#10;route_priority      &#61; number&#10;&#125;&#41;&#10;bgp_session_range               &#61; string&#10;ike_version                     &#61; number&#10;peer_external_gateway_interface &#61; number&#10;router                          &#61; string&#10;shared_secret                   &#61; string&#10;vpn_gateway_interface           &#61; number&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |
 | *vpn_gateway* | HA VPN Gateway Self Link for using an existing HA VPN Gateway, leave empty if `vpn_gateway_create` is set to `true`. | <code title="">string</code> |  | <code title="">null</code> |
 | *vpn_gateway_create* | Create HA VPN Gateway. | <code title="">bool</code> |  | <code title="">true</code> |
 

--- a/modules/net-vpn-ha/variables.tf
+++ b/modules/net-vpn-ha/variables.tf
@@ -115,9 +115,10 @@ variable "tunnels" {
     # from the 169.254.0.0/16 block.
     bgp_session_range               = string
     ike_version                     = number
-    vpn_gateway_interface           = number
     peer_external_gateway_interface = number
+    router                          = string
     shared_secret                   = string
+    vpn_gateway_interface           = number
   }))
   default = {}
 }

--- a/networking/hub-and-spoke-vpn/main.tf
+++ b/networking/hub-and-spoke-vpn/main.tf
@@ -79,6 +79,7 @@ module "vpn-hub-a" {
       bgp_session_range = "${cidrhost(var.bgp_interface_ranges.spoke-1, 1)}/30"
       ike_version       = 2
       peer_ip           = module.vpn-spoke-1.address
+      router            = null
       shared_secret     = ""
     }
   }
@@ -108,6 +109,7 @@ module "vpn-hub-b" {
       bgp_session_range = "${cidrhost(var.bgp_interface_ranges.spoke-2, 1)}/30"
       ike_version       = 2
       peer_ip           = module.vpn-spoke-2.address
+      router            = null
       shared_secret     = ""
     }
   }
@@ -162,6 +164,7 @@ module "vpn-spoke-1" {
       bgp_session_range = "${cidrhost(var.bgp_interface_ranges.spoke-1, 2)}/30"
       ike_version       = 2
       peer_ip           = module.vpn-hub-a.address
+      router            = null
       shared_secret     = module.vpn-hub-a.random_secret
     }
   }
@@ -225,6 +228,7 @@ module "vpn-spoke-2" {
       bgp_session_range = "${cidrhost(var.bgp_interface_ranges.spoke-2, 2)}/30"
       ike_version       = 2
       peer_ip           = module.vpn-hub-b.address
+      router            = null
       shared_secret     = module.vpn-hub-b.random_secret
     }
   }

--- a/networking/onprem-google-access-dns/main.tf
+++ b/networking/onprem-google-access-dns/main.tf
@@ -105,6 +105,7 @@ module "vpn1" {
       bgp_session_range = "${local.bgp_interface_gcp1}/30"
       ike_version       = 2
       peer_ip           = module.vm-onprem.external_ips.0
+      router            = null
       shared_secret     = ""
     }
   }
@@ -136,6 +137,7 @@ module "vpn2" {
       bgp_session_range = "${local.bgp_interface_gcp2}/30"
       ike_version       = 2
       peer_ip           = module.vm-onprem.external_ips.0
+      router            = null
       shared_secret     = ""
     }
   }


### PR DESCRIPTION
This allows setting a different router for specific tunnels associated with a single VPN gateway.