### PR TITLE
Support for Cloud Logging buckets

### DIFF
--- a/modules/folder/main.tf
+++ b/modules/folder/main.tf
@@ -30,8 +30,7 @@ locals {
     gcs      = "storage.googleapis.com"
     bigquery = "bigquery.googleapis.com"
     pubsub   = "pubsub.googleapis.com"
-    # TODO: add logging buckets support
-    # logging  = "logging.googleapis.com"
+    logging  = "logging.googleapis.com"
   }
   sink_bindings = {
     for type in ["gcs", "bigquery", "pubsub", "logging"] :
@@ -192,6 +191,15 @@ resource "google_logging_folder_sink" "sink" {
   destination      = "${local.sink_type_destination[each.value.type]}/${each.value.destination}"
   filter           = each.value.filter
   include_children = each.value.include_children
+
+  dynamic "exclusions" {
+    for_each = each.value.exclusions
+    iterator = exclusion
+    content {
+      name   = exclusion.key
+      filter = exclusion.value
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "gcs-sinks-binding" {

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -83,6 +83,8 @@ variable "logging_sinks" {
     filter           = string
     iam              = bool
     include_children = bool
+    # TODO exclusions also support description and disabled
+    exclusions = map(string)
   }))
   default = {}
 }

--- a/modules/logging-bucket/README.md
+++ b/modules/logging-bucket/README.md
@@ -1,0 +1,61 @@
+# Google Cloud Logging Buckets Module
+
+This module manages [logging buckets](https://cloud.google.com/logging/docs/storage#logs-buckets) for a project, folder, organization or billing account.
+
+Note that some logging buckets are automatically created for a given folder, project, organization, and billing account cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
+
+See also the `logging_sinks` argument within the [project](../project/), [folder](../folder/) and [organization](../organization) modules.
+
+## Examples
+
+### Create custom logging bucket in a project
+
+```hcl
+module "bucket" {
+  source      = "./modules/logging-bucket"
+  parent_type = "project"
+  parent      = var.project_id
+  id          = "mybucket"
+}
+# tftest:modules=1:resources=1
+```
+
+
+### Change retention period of a folder's _Default bucket
+
+```hcl
+module "folder" {
+  source = "./modules/folder"
+  parent = "folders/657104291943"
+  name   = "my folder"
+}
+
+module "bucket-default" {
+  source      = "./modules/logging-bucket"
+  parent_type = "folder"
+  parent      = module.folder.id
+  id          = "_Default"
+  retention   = 10
+}
+# tftest:modules=2:resources=2
+```
+
+
+<!-- BEGIN TFDOC -->
+## Variables
+
+| name | description | type | required | default |
+|---|---|:---: |:---:|:---:|
+| id | Name of the logging bucket. | <code title="">string</code> | ✓ |  |
+| parent | ID of the parentresource containing the bucket in the format 'project_id' 'folders/folder_id', 'organizations/organization_id' or 'billing_account_id'. | <code title="">string</code> | ✓ |  |
+| parent_type | Parent object type for the bucket (project, folder, organization, billing_account). | <code title="">string</code> | ✓ |  |
+| *description* | Human-readable description for the logging bucket. | <code title="">string</code> |  | <code title="">null</code> |
+| *location* | Location of the bucket. | <code title="">string</code> |  | <code title="">global</code> |
+| *retention* | Retention time in days for the logging bucket. | <code title="">number</code> |  | <code title="">30</code> |
+
+## Outputs
+
+| name | description | sensitive |
+|---|---|:---:|
+| id | None |  |
+<!-- END TFDOC -->

--- a/modules/logging-bucket/main.tf
+++ b/modules/logging-bucket/main.tf
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_logging_project_bucket_config" "bucket" {
+  count          = var.parent_type == "project" ? 1 : 0
+  project        = var.parent
+  location       = var.location
+  retention_days = var.retention
+  bucket_id      = var.id
+  description    = var.description
+}
+
+resource "google_logging_folder_bucket_config" "bucket" {
+  count          = var.parent_type == "folder" ? 1 : 0
+  folder         = var.parent
+  location       = var.location
+  retention_days = var.retention
+  bucket_id      = var.id
+  description    = var.description
+}
+
+resource "google_logging_organization_bucket_config" "bucket" {
+  count          = var.parent_type == "organization" ? 1 : 0
+  organization   = var.parent
+  location       = var.location
+  retention_days = var.retention
+  bucket_id      = var.id
+  description    = var.description
+}
+
+resource "google_logging_billing_account_bucket_config" "bucket" {
+  count           = var.parent_type == "billing_account" ? 1 : 0
+  billing_account = var.parent
+  location        = var.location
+  retention_days  = var.retention
+  bucket_id       = var.id
+  description     = var.description
+}

--- a/modules/logging-bucket/outputs.tf
+++ b/modules/logging-bucket/outputs.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "id" {
+  value = try(
+    google_logging_project_bucket_config.bucket.0.id,
+    google_logging_folder_bucket_config.bucket.0.id,
+    google_logging_organization_bucket_config.bucket.0.id,
+    google_logging_billing_account_bucket_config.bucket.0.id,
+  )
+}

--- a/modules/logging-bucket/variables.tf
+++ b/modules/logging-bucket/variables.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent_type" {
+  description = "Parent object type for the bucket (project, folder, organization, billing_account)."
+  type        = string
+}
+
+variable "parent" {
+  description = "ID of the parentresource containing the bucket in the format 'project_id' 'folders/folder_id', 'organizations/organization_id' or 'billing_account_id'."
+  type        = string
+}
+
+variable "location" {
+  description = "Location of the bucket."
+  type        = string
+  default     = "global"
+}
+
+variable "id" {
+  description = "Name of the logging bucket."
+  type        = string
+}
+
+variable "description" {
+  description = "Human-readable description for the logging bucket."
+  type        = string
+  default     = null
+}
+
+variable "retention" {
+  description = "Retention time in days for the logging bucket."
+  type        = number
+  default     = 30
+}

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -45,8 +45,7 @@ locals {
     gcs      = "storage.googleapis.com"
     bigquery = "bigquery.googleapis.com"
     pubsub   = "pubsub.googleapis.com"
-    # TODO: add logging buckets support
-    # logging  = "logging.googleapis.com"
+    logging  = "logging.googleapis.com"
   }
   sink_bindings = {
     for type in ["gcs", "bigquery", "pubsub", "logging"] :
@@ -256,6 +255,15 @@ resource "google_logging_organization_sink" "sink" {
   destination      = "${local.sink_type_destination[each.value.type]}/${each.value.destination}"
   filter           = each.value.filter
   include_children = each.value.include_children
+
+  dynamic "exclusions" {
+    for_each = each.value.exclusions
+    iterator = exclusion
+    content {
+      name   = exclusion.key
+      filter = exclusion.value
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "gcs-sinks-binding" {

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -124,6 +124,8 @@ variable "logging_sinks" {
     filter           = string
     iam              = bool
     include_children = bool
+    # TODO exclusions also support description and disabled
+    exclusions = map(string)
   }))
   default = {}
 }

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -169,10 +169,13 @@ variable "shared_vpc_service_config" {
 variable "logging_sinks" {
   description = "Logging sinks to create for this project."
   type = map(object({
-    destination = string
-    type        = string
-    filter      = string
-    iam         = bool
+    destination   = string
+    type          = string
+    filter        = string
+    iam           = bool
+    unique_writer = bool
+    # TODO exclusions also support description and disabled
+    exclusions = map(string)
   }))
   default = {}
 }

--- a/tests/modules/folder/fixture/variables.tf
+++ b/tests/modules/folder/fixture/variables.tf
@@ -61,6 +61,7 @@ variable "logging_sinks" {
     filter           = string
     iam              = bool
     include_children = bool
+    exclusions       = map(string)
   }))
   default = {}
 }

--- a/tests/modules/folder/test_plan_logging.py
+++ b/tests/modules/folder/test_plan_logging.py
@@ -18,18 +18,19 @@ import pytest
 
 from collections import Counter
 
-FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixture")
 
 
 def test_sinks(plan_runner):
-  "Test folder-level sinks."
-  logging_sinks = """ {
+    "Test folder-level sinks."
+    logging_sinks = """ {
     warning = {
       type             = "gcs"
       destination      = "mybucket"
       filter           = "severity=WARNING"
       iam              = true
       include_children = true
+      exclusions       = {}
     }
     info = {
       type             = "bigquery"
@@ -37,6 +38,7 @@ def test_sinks(plan_runner):
       filter           = "severity=INFO"
       iam              = true
       include_children = true
+      exclusions       = {}
     }
     notice = {
       type             = "pubsub"
@@ -44,72 +46,123 @@ def test_sinks(plan_runner):
       filter           = "severity=NOTICE"
       iam              = true
       include_children = false
+      exclusions       = {}
+    }
+    debug = {
+      type             = "logging"
+      destination      = "projects/myproject/locations/global/buckets/mybucket"
+      filter           = "severity=DEBUG"
+      iam              = true
+      include_children = false
+      exclusions    = {
+        no-compute   = "logName:compute"
+        no-container = "logName:container"
+      }
     }
   }
   """
-  _, resources = plan_runner(FIXTURES_DIR, logging_sinks=logging_sinks)
-  assert len(resources) == 7
+    _, resources = plan_runner(FIXTURES_DIR, logging_sinks=logging_sinks)
+    assert len(resources) == 8
 
-  resource_types = Counter([r['type'] for r in resources])
-  assert resource_types == {
-    'google_bigquery_dataset_iam_binding': 1,
-    'google_folder': 1,
-    'google_logging_folder_sink': 3,
-    'google_pubsub_topic_iam_binding': 1,
-    'google_storage_bucket_iam_binding': 1
-  }
-  
-  sinks = [r for r in resources
-           if r['type'] == 'google_logging_folder_sink']
-  assert sorted([r['index'] for r in sinks]) == [
-      'info',
-      'notice',
-      'warning',
-  ]
-  values = [(r['index'], r['values']['filter'], r['values']['destination'],
-             r['values']['include_children'])
-            for r in sinks]
-  assert sorted(values) == [
-    ('info',
-     'severity=INFO',
-     'bigquery.googleapis.com/projects/myproject/datasets/mydataset',
-     True),
-    ('notice',
-     'severity=NOTICE',
-     'pubsub.googleapis.com/projects/myproject/topics/mytopic',
-     False),
-    ('warning', 'severity=WARNING', 'storage.googleapis.com/mybucket', True)]
+    resource_types = Counter([r["type"] for r in resources])
+    assert resource_types == {
+        "google_bigquery_dataset_iam_binding": 1,
+        "google_folder": 1,
+        "google_logging_folder_sink": 4,
+        "google_pubsub_topic_iam_binding": 1,
+        "google_storage_bucket_iam_binding": 1,
+    }
 
-  bindings = [r for r in resources
-              if 'binding' in r['type']]
-  values = [(r['index'], r['type'], r['values']['role'])
-            for r in bindings]
-  assert sorted(values) == [
-    ('info', 'google_bigquery_dataset_iam_binding', 'roles/bigquery.dataEditor'),
-    ('notice', 'google_pubsub_topic_iam_binding', 'roles/pubsub.publisher'),
-    ('warning', 'google_storage_bucket_iam_binding', 'roles/storage.objectCreator')
-  ]
+    sinks = [r for r in resources if r["type"] == "google_logging_folder_sink"]
+    assert sorted([r["index"] for r in sinks]) == [
+        "debug",
+        "info",
+        "notice",
+        "warning",
+    ]
+    values = [
+        (
+            r["index"],
+            r["values"]["filter"],
+            r["values"]["destination"],
+            r["values"]["include_children"],
+        )
+        for r in sinks
+    ]
+    assert sorted(values) == [
+        (
+            "debug",
+            "severity=DEBUG",
+            "logging.googleapis.com/projects/myproject/locations/global/buckets/mybucket",
+            False,
+        ),
+        (
+            "info",
+            "severity=INFO",
+            "bigquery.googleapis.com/projects/myproject/datasets/mydataset",
+            True,
+        ),
+        (
+            "notice",
+            "severity=NOTICE",
+            "pubsub.googleapis.com/projects/myproject/topics/mytopic",
+            False,
+        ),
+        ("warning", "severity=WARNING", "storage.googleapis.com/mybucket", True),
+    ]
 
-  
+    bindings = [r for r in resources if "binding" in r["type"]]
+    values = [(r["index"], r["type"], r["values"]["role"]) for r in bindings]
+    assert sorted(values) == [
+        ("info", "google_bigquery_dataset_iam_binding", "roles/bigquery.dataEditor"),
+        ("notice", "google_pubsub_topic_iam_binding", "roles/pubsub.publisher"),
+        ("warning", "google_storage_bucket_iam_binding", "roles/storage.objectCreator"),
+    ]
+
+    exclusions = [(r["index"], r["values"]["exclusions"]) for r in sinks]
+    assert sorted(exclusions) == [
+        (
+            "debug",
+            [
+                {
+                    "description": None,
+                    "disabled": False,
+                    "filter": "logName:compute",
+                    "name": "no-compute",
+                },
+                {
+                    "description": None,
+                    "disabled": False,
+                    "filter": "logName:container",
+                    "name": "no-container",
+                },
+            ],
+        ),
+        ("info", []),
+        ("notice", []),
+        ("warning", []),
+    ]
+
+
 def test_exclusions(plan_runner):
-  "Test folder-level logging exclusions."
-  logging_exclusions = (
-      '{'
-      'exclusion1 = "resource.type=gce_instance", '
-      'exclusion2 = "severity=NOTICE", '
-      '}'
-  )
-  _, resources = plan_runner(FIXTURES_DIR,
-                             logging_exclusions=logging_exclusions)
-  assert len(resources) == 3
-  exclusions = [r for r in resources
-                if r['type'] == 'google_logging_folder_exclusion']
-  assert sorted([r['index'] for r in exclusions]) == [
-      'exclusion1',
-      'exclusion2',
-  ]
-  values = [(r['index'], r['values']['filter']) for r in exclusions]
-  assert sorted(values) == [
-    ('exclusion1', 'resource.type=gce_instance'),
-    ('exclusion2', 'severity=NOTICE')
-  ]
+    "Test folder-level logging exclusions."
+    logging_exclusions = (
+        "{"
+        'exclusion1 = "resource.type=gce_instance", '
+        'exclusion2 = "severity=NOTICE", '
+        "}"
+    )
+    _, resources = plan_runner(FIXTURES_DIR, logging_exclusions=logging_exclusions)
+    assert len(resources) == 3
+    exclusions = [
+        r for r in resources if r["type"] == "google_logging_folder_exclusion"
+    ]
+    assert sorted([r["index"] for r in exclusions]) == [
+        "exclusion1",
+        "exclusion2",
+    ]
+    values = [(r["index"], r["values"]["filter"]) for r in exclusions]
+    assert sorted(values) == [
+        ("exclusion1", "resource.type=gce_instance"),
+        ("exclusion2", "severity=NOTICE"),
+    ]

--- a/tests/modules/logging_bucket/__init__.py
+++ b/tests/modules/logging_bucket/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/logging_bucket/fixture/main.tf
+++ b/tests/modules/logging_bucket/fixture/main.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source      = "../../../../modules/logging-bucket"
+  parent_type = var.parent_type
+  parent      = var.parent
+  id          = var.id
+  retention   = var.retention
+  location    = var.location
+}

--- a/tests/modules/logging_bucket/fixture/variables.tf
+++ b/tests/modules/logging_bucket/fixture/variables.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent" {
+  type = string
+}
+
+variable "parent_type" {
+  type = string
+  validation {
+    condition     = contains(["project", "folder", "organization", "billing_account"], var.parent_type)
+    error_message = "Parent type must be project, folder, organization or billing_account."
+  }
+}
+
+variable "location" {
+  type    = string
+  default = "global"
+}
+
+variable "id" {
+  type    = string
+  default = "mybucket"
+}
+
+variable "retention" {
+  type    = number
+  default = 30
+}

--- a/tests/modules/logging_bucket/test_plan.py
+++ b/tests/modules/logging_bucket/test_plan.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import pytest
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixture")
+
+
+def test_project_logging_bucket(plan_runner):
+    "Test project logging bucket."
+    _, resources = plan_runner(FIXTURES_DIR, parent_type="project", parent="myproject")
+    assert len(resources) == 1
+
+    resource = resources[0]
+    assert resource["type"] == "google_logging_project_bucket_config"
+    assert resource["values"] == {
+        "bucket_id": "mybucket",
+        "project": "myproject",
+        "location": "global",
+        "retention_days": 30,
+    }
+
+
+def test_folder_logging_bucket(plan_runner):
+    "Test project logging bucket."
+    _, resources = plan_runner(
+        FIXTURES_DIR, parent_type="folder", parent="folders/0123456789"
+    )
+    assert len(resources) == 1
+
+    resource = resources[0]
+    assert resource["type"] == "google_logging_folder_bucket_config"
+    assert resource["values"] == {
+        "bucket_id": "mybucket",
+        "folder": "folders/0123456789",
+        "location": "global",
+        "retention_days": 30,
+    }
+
+
+def test_organization_logging_bucket(plan_runner):
+    "Test project logging bucket."
+    _, resources = plan_runner(
+        FIXTURES_DIR, parent_type="organization", parent="organizations/0123456789"
+    )
+    assert len(resources) == 1
+
+    resource = resources[0]
+    assert resource["type"] == "google_logging_organization_bucket_config"
+    assert resource["values"] == {
+        "bucket_id": "mybucket",
+        "organization": "organizations/0123456789",
+        "location": "global",
+        "retention_days": 30,
+    }
+
+
+def test_billing_account_logging_bucket(plan_runner):
+    "Test project logging bucket."
+    _, resources = plan_runner(
+        FIXTURES_DIR, parent_type="billing_account", parent="0123456789"
+    )
+    assert len(resources) == 1
+
+    resource = resources[0]
+    assert resource["type"] == "google_logging_billing_account_bucket_config"
+    assert resource["values"] == {
+        "bucket_id": "mybucket",
+        "billing_account": "0123456789",
+        "location": "global",
+        "retention_days": 30,
+    }

--- a/tests/modules/organization/fixture/variables.tf
+++ b/tests/modules/organization/fixture/variables.tf
@@ -81,6 +81,7 @@ variable "logging_sinks" {
     filter           = string
     iam              = bool
     include_children = bool
+    exclusions       = map(string)
   }))
   default = {}
 }

--- a/tests/modules/organization/test_plan_logging.py
+++ b/tests/modules/organization/test_plan_logging.py
@@ -18,18 +18,19 @@ import pytest
 
 from collections import Counter
 
-FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixture")
 
 
 def test_sinks(plan_runner):
-  "Test folder-level sinks."
-  logging_sinks = """ {
+    "Test folder-level sinks."
+    logging_sinks = """ {
     warning = {
       type             = "gcs"
       destination      = "mybucket"
       filter           = "severity=WARNING"
       iam              = true
       include_children = true
+      exclusions       = {}
     }
     info = {
       type             = "bigquery"
@@ -37,6 +38,7 @@ def test_sinks(plan_runner):
       filter           = "severity=INFO"
       iam              = true
       include_children = true
+      exclusions       = {}
    }
     notice = {
       type             = "pubsub"
@@ -44,71 +46,122 @@ def test_sinks(plan_runner):
       filter           = "severity=NOTICE"
       iam              = true
       include_children = false
+      exclusions       = {}
+    }
+    debug = {
+      type             = "logging"
+      destination      = "projects/myproject/locations/global/buckets/mybucket"
+      filter           = "severity=DEBUG"
+      iam              = true
+      include_children = false
+      exclusions    = {
+        no-compute   = "logName:compute"
+        no-container = "logName:container"
+      }
     }
   }
   """
-  _, resources = plan_runner(FIXTURES_DIR, logging_sinks=logging_sinks)
-  assert len(resources) == 6
+    _, resources = plan_runner(FIXTURES_DIR, logging_sinks=logging_sinks)
+    assert len(resources) == 7
 
-  resource_types = Counter([r['type'] for r in resources])
-  assert resource_types == {
-    'google_bigquery_dataset_iam_binding': 1,
-    'google_logging_organization_sink': 3,
-    'google_pubsub_topic_iam_binding': 1,
-    'google_storage_bucket_iam_binding': 1
-  }
-  
-  sinks = [r for r in resources
-           if r['type'] == 'google_logging_organization_sink']
-  assert sorted([r['index'] for r in sinks]) == [
-      'info',
-      'notice',
-      'warning',
-  ]
-  values = [(r['index'], r['values']['filter'], r['values']['destination'],
-             r['values']['include_children'])
-            for r in sinks]
-  assert sorted(values) == [
-    ('info',
-     'severity=INFO',
-     'bigquery.googleapis.com/projects/myproject/datasets/mydataset',
-     True),
-    ('notice',
-     'severity=NOTICE',
-     'pubsub.googleapis.com/projects/myproject/topics/mytopic',
-     False),
-    ('warning', 'severity=WARNING', 'storage.googleapis.com/mybucket', True)]
+    resource_types = Counter([r["type"] for r in resources])
+    assert resource_types == {
+        "google_bigquery_dataset_iam_binding": 1,
+        "google_logging_organization_sink": 4,
+        "google_pubsub_topic_iam_binding": 1,
+        "google_storage_bucket_iam_binding": 1,
+    }
 
-  bindings = [r for r in resources
-              if 'binding' in r['type']]
-  values = [(r['index'], r['type'], r['values']['role'])
-            for r in bindings]
-  assert sorted(values) == [
-    ('info', 'google_bigquery_dataset_iam_binding', 'roles/bigquery.dataEditor'),
-    ('notice', 'google_pubsub_topic_iam_binding', 'roles/pubsub.publisher'),
-    ('warning', 'google_storage_bucket_iam_binding', 'roles/storage.objectCreator')
-  ]
+    sinks = [r for r in resources if r["type"] == "google_logging_organization_sink"]
+    assert sorted([r["index"] for r in sinks]) == [
+        "debug",
+        "info",
+        "notice",
+        "warning",
+    ]
+    values = [
+        (
+            r["index"],
+            r["values"]["filter"],
+            r["values"]["destination"],
+            r["values"]["include_children"],
+        )
+        for r in sinks
+    ]
+    assert sorted(values) == [
+        (
+            "debug",
+            "severity=DEBUG",
+            "logging.googleapis.com/projects/myproject/locations/global/buckets/mybucket",
+            False,
+        ),
+        (
+            "info",
+            "severity=INFO",
+            "bigquery.googleapis.com/projects/myproject/datasets/mydataset",
+            True,
+        ),
+        (
+            "notice",
+            "severity=NOTICE",
+            "pubsub.googleapis.com/projects/myproject/topics/mytopic",
+            False,
+        ),
+        ("warning", "severity=WARNING", "storage.googleapis.com/mybucket", True),
+    ]
 
-  
+    bindings = [r for r in resources if "binding" in r["type"]]
+    values = [(r["index"], r["type"], r["values"]["role"]) for r in bindings]
+    assert sorted(values) == [
+        ("info", "google_bigquery_dataset_iam_binding", "roles/bigquery.dataEditor"),
+        ("notice", "google_pubsub_topic_iam_binding", "roles/pubsub.publisher"),
+        ("warning", "google_storage_bucket_iam_binding", "roles/storage.objectCreator"),
+    ]
+
+    exclusions = [(r["index"], r["values"]["exclusions"]) for r in sinks]
+    assert sorted(exclusions) == [
+        (
+            "debug",
+            [
+                {
+                    "description": None,
+                    "disabled": False,
+                    "filter": "logName:compute",
+                    "name": "no-compute",
+                },
+                {
+                    "description": None,
+                    "disabled": False,
+                    "filter": "logName:container",
+                    "name": "no-container",
+                },
+            ],
+        ),
+        ("info", []),
+        ("notice", []),
+        ("warning", []),
+    ]
+
+
 def test_exclusions(plan_runner):
-  "Test folder-level logging exclusions."
-  logging_exclusions = (
-      '{'
-      'exclusion1 = "resource.type=gce_instance", '
-      'exclusion2 = "severity=NOTICE", '
-      '}'
-  )
-  _, resources = plan_runner(FIXTURES_DIR,
-                             logging_exclusions=logging_exclusions)
-  assert len(resources) == 2
-  exclusions = [r for r in resources
-                if r['type'] == 'google_logging_organization_exclusion']
-  assert sorted([r['index'] for r in exclusions]) == [
-      'exclusion1',
-      'exclusion2',
-  ]
-  values = [(r['index'], r['values']['filter']) for r in exclusions]
-  assert sorted(values) == [
-    ('exclusion1', 'resource.type=gce_instance'),
-    ('exclusion2', 'severity=NOTICE')
-  ]
+    "Test folder-level logging exclusions."
+    logging_exclusions = (
+        "{"
+        'exclusion1 = "resource.type=gce_instance", '
+        'exclusion2 = "severity=NOTICE", '
+        "}"
+    )
+    _, resources = plan_runner(FIXTURES_DIR, logging_exclusions=logging_exclusions)
+    assert len(resources) == 2
+    exclusions = [
+        r for r in resources if r["type"] == "google_logging_organization_exclusion"
+    ]
+    assert sorted([r["index"] for r in exclusions]) == [
+        "exclusion1",
+        "exclusion2",
+    ]
+    values = [(r["index"], r["values"]["filter"]) for r in exclusions]
+    assert sorted(values) == [
+        ("exclusion1", "resource.type=gce_instance"),
+        ("exclusion2", "severity=NOTICE"),
+    ]

--- a/tests/modules/project/fixture/variables.tf
+++ b/tests/modules/project/fixture/variables.tf
@@ -96,10 +96,12 @@ variable "services" {
 
 variable "logging_sinks" {
   type = map(object({
-    destination = string
-    type        = string
-    filter      = string
-    iam         = bool
+    destination   = string
+    type          = string
+    filter        = string
+    iam           = bool
+    exclusions    = map(string)
+    unique_writer = bool
   }))
   default = {}
 }


### PR DESCRIPTION
This PR:
- Introduces a new module `logging-bucket` to create [Cloud Logging Buckets](https://cloud.google.com/logging/docs/storage#logs-buckets)
- Adds support to create logging sinks using logging buckets as the destination
- Extends existing logging sinks to support per-sink exclusions