### PR TITLE
Set version for google-beta provider in project module

### DIFF
--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,6 +17,7 @@
 terraform {
   required_version = ">= 0.13.0"
   required_providers {
-    google = "~> 3.57"
+    google      = "~> 3.57"
+    google-beta = "~> 3.57"
   }
 }


### PR DESCRIPTION
The new essential contacts resource uses the beta provider.