### PR TITLE
Allow DNS zones visible to no VPCs

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -42,7 +42,7 @@ resource "google_dns_managed_zone" "non-public" {
   description = var.description
   visibility  = "private"
 
-  dynamic forwarding_config {
+  dynamic "forwarding_config" {
     for_each = (
       var.type == "forwarding" &&
       var.forwarders != null &&
@@ -62,7 +62,7 @@ resource "google_dns_managed_zone" "non-public" {
     }
   }
 
-  dynamic peering_config {
+  dynamic "peering_config" {
     for_each = (
       var.type == "peering" && var.peer_network != null ? [""] : []
     )
@@ -73,17 +73,20 @@ resource "google_dns_managed_zone" "non-public" {
     }
   }
 
-  private_visibility_config {
-    dynamic "networks" {
-      for_each = var.client_networks
-      iterator = network
-      content {
-        network_url = network.value
+  dynamic "private_visibility_config" {
+    for_each = length(var.client_networks) > 0 ? [""] : []
+    content {
+      dynamic "networks" {
+        for_each = var.client_networks
+        iterator = network
+        content {
+          network_url = network.value
+        }
       }
     }
   }
 
-  dynamic service_directory_config {
+  dynamic "service_directory_config" {
     for_each = (
       var.type == "service-directory" && var.service_directory_namespace != null
       ? [""]

--- a/tests/modules/dns/fixture/main.tf
+++ b/tests/modules/dns/fixture/main.tf
@@ -15,15 +15,13 @@
  */
 
 module "test" {
-  source     = "../../../../modules/dns"
-  project_id = "my-project"
-  name       = "test"
-  domain     = "test.example."
-  client_networks = [
-    "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default"
-  ]
-  type         = var.type
-  forwarders   = var.forwarders
-  peer_network = var.peer_network
-  recordsets   = var.recordsets
+  source          = "../../../../modules/dns"
+  project_id      = "my-project"
+  name            = "test"
+  domain          = "test.example."
+  client_networks = var.client_networks
+  type            = var.type
+  forwarders      = var.forwarders
+  peer_network    = var.peer_network
+  recordsets      = var.recordsets
 }

--- a/tests/modules/dns/fixture/variables.tf
+++ b/tests/modules/dns/fixture/variables.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+variable "client_networks" {
+  type = list(string)
+  default = [
+    "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default"
+  ]
+}
+
 variable "forwarders" {
   type    = map(string)
   default = {}

--- a/tests/modules/dns/test_plan.py
+++ b/tests/modules/dns/test_plan.py
@@ -34,6 +34,20 @@ def test_private(plan_runner):
     assert len(r['values']['private_visibility_config']) == 1
 
 
+def test_private_no_networks(plan_runner):
+  "Test private zone not exposed to any network."
+  _, resources = plan_runner(FIXTURES_DIR, client_networks='[]')
+  assert len(resources) == 3
+  assert set(r['type'] for r in resources) == set([
+      'google_dns_record_set', 'google_dns_managed_zone'
+  ])
+  for r in resources:
+    if r['type'] != 'google_dns_managed_zone':
+      continue
+    assert r['values']['visibility'] == 'private'
+    assert len(r['values']['private_visibility_config']) == 0
+
+
 def test_forwarding_recordsets_null_forwarders(plan_runner):
   "Test forwarding zone with wrong set of attributes does not break."
   _, resources = plan_runner(FIXTURES_DIR, type='forwarding')


### PR DESCRIPTION
This fixes a bug in private DNS zones, where visibiity for at least one VPC was required.