### PR TITLE
Add support for group-based IAM to resource management modules

### DIFF
--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -161,7 +161,6 @@ module "folder2" {
 # tftest:modules=2:resources=6
 ```
 
-
 <!-- BEGIN TFDOC -->
 ## Variables
 
@@ -171,7 +170,7 @@ module "folder2" {
 | *firewall_policies* | Hierarchical firewall policies to *create* in this folder. | <code title="map&#40;map&#40;object&#40;&#123;&#10;description             &#61; string&#10;direction               &#61; string&#10;action                  &#61; string&#10;priority                &#61; number&#10;ranges                  &#61; list&#40;string&#41;&#10;ports                   &#61; map&#40;list&#40;string&#41;&#41;&#10;target_service_accounts &#61; list&#40;string&#41;&#10;target_resources        &#61; list&#40;string&#41;&#10;logging                 &#61; bool&#10;&#125;&#41;&#41;&#41;">map(map(object({...})))</code> |  | <code title="">{}</code> |
 | *firewall_policy_attachments* | List of hierarchical firewall policy IDs to *attach* to this folder. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *folder_create* | Create folder. When set to false, uses id to reference an existing folder. | <code title="">bool</code> |  | <code title="">true</code> |
-| *group_iam* | Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
+| *group_iam* | Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *id* | Folder ID in case you use folder_create=false | <code title="">string</code> |  | <code title="">null</code> |
 | *logging_exclusions* | Logging exclusions for this folder in the form {NAME -> FILTER}. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Folder Module
 
-This module allows the creation and management of folders together with their individual IAM bindings and organization policies.
+This module allows the creation and management of folders, including support for IAM bindings, organization policies, and hierarchical firewall rules.
 
 ## Examples
 
@@ -11,11 +11,14 @@ module "folder" {
   source = "./modules/folder"
   parent = "organizations/1234567890"
   name  = "Folder name"
+  group_iam       = {
+    "cloud-owners@example.org" = ["roles/owner", "roles/projectCreator"]
+  }
   iam = {
-    "roles/owner" = ["group:users@example.com"]
+    "roles/owner" = ["user:one@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest:modules=1:resources=3
 ```
 
 ### Organization policies
@@ -168,7 +171,8 @@ module "folder2" {
 | *firewall_policies* | Hierarchical firewall policies to *create* in this folder. | <code title="map&#40;map&#40;object&#40;&#123;&#10;description             &#61; string&#10;direction               &#61; string&#10;action                  &#61; string&#10;priority                &#61; number&#10;ranges                  &#61; list&#40;string&#41;&#10;ports                   &#61; map&#40;list&#40;string&#41;&#41;&#10;target_service_accounts &#61; list&#40;string&#41;&#10;target_resources        &#61; list&#40;string&#41;&#10;logging                 &#61; bool&#10;&#125;&#41;&#41;&#41;">map(map(object({...})))</code> |  | <code title="">{}</code> |
 | *firewall_policy_attachments* | List of hierarchical firewall policy IDs to *attach* to this folder. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *folder_create* | Create folder. When set to false, uses id to reference an existing folder. | <code title="">bool</code> |  | <code title="">true</code> |
-| *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;set&#40;string&#41;&#41;">map(set(string))</code> |  | <code title="">{}</code> |
+| *group_iam* | Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
+| *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *id* | Folder ID in case you use folder_create=false | <code title="">string</code> |  | <code title="">null</code> |
 | *logging_exclusions* | Logging exclusions for this folder in the form {NAME -> FILTER}. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
 | *logging_sinks* | Logging sinks to create for this folder. | <code title="map&#40;object&#40;&#123;&#10;destination      &#61; string&#10;type &#61; string&#10;filter           &#61; string&#10;iam              &#61; bool&#10;include_children &#61; bool&#10;exclusions &#61; map&#40;string&#41;&#10;&#125;&#41;&#41;">map(object({...}))</code> |  | <code title="">{}</code> |

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -49,7 +49,7 @@ variable "folder_create" {
 }
 
 variable "group_iam" {
-  description = "Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
+  description = "Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
   type        = map(list(string))
   default     = {}
 }

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -14,9 +14,75 @@
  * limitations under the License.
  */
 
+variable "contacts" {
+  description = "List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "firewall_policies" {
+  description = "Hierarchical firewall policies to *create* in this folder."
+  type = map(map(object({
+    description             = string
+    direction               = string
+    action                  = string
+    priority                = number
+    ranges                  = list(string)
+    ports                   = map(list(string))
+    target_service_accounts = list(string)
+    target_resources        = list(string)
+    logging                 = bool
+  })))
+  default = {}
+}
+
+variable "firewall_policy_attachments" {
+  description = "List of hierarchical firewall policy IDs to *attach* to this folder."
+  type        = map(string)
+  default     = {}
+}
+
+variable "folder_create" {
+  description = "Create folder. When set to false, uses id to reference an existing folder."
+  type        = bool
+  default     = true
+}
+
+variable "group_iam" {
+  description = "Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "iam" {
   description = "IAM bindings in {ROLE => [MEMBERS]} format."
-  type        = map(set(string))
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "id" {
+  description = "Folder ID in case you use folder_create=false"
+  type        = string
+  default     = null
+}
+
+variable "logging_sinks" {
+  description = "Logging sinks to create for this folder."
+  type = map(object({
+    destination      = string
+    type             = string
+    filter           = string
+    iam              = bool
+    include_children = bool
+    # TODO exclusions also support description and disabled
+    exclusions = map(string)
+  }))
+  default = {}
+}
+
+variable "logging_exclusions" {
+  description = "Logging exclusions for this folder in the form {NAME -> FILTER}."
+  type        = map(string)
   default     = {}
 }
 
@@ -51,64 +117,4 @@ variable "policy_list" {
     values              = list(string)
   }))
   default = {}
-}
-
-variable "firewall_policies" {
-  description = "Hierarchical firewall policies to *create* in this folder."
-  type = map(map(object({
-    description             = string
-    direction               = string
-    action                  = string
-    priority                = number
-    ranges                  = list(string)
-    ports                   = map(list(string))
-    target_service_accounts = list(string)
-    target_resources        = list(string)
-    logging                 = bool
-  })))
-  default = {}
-}
-
-variable "firewall_policy_attachments" {
-  description = "List of hierarchical firewall policy IDs to *attach* to this folder."
-  type        = map(string)
-  default     = {}
-}
-
-variable "logging_sinks" {
-  description = "Logging sinks to create for this folder."
-  type = map(object({
-    destination      = string
-    type             = string
-    filter           = string
-    iam              = bool
-    include_children = bool
-    # TODO exclusions also support description and disabled
-    exclusions = map(string)
-  }))
-  default = {}
-}
-
-variable "logging_exclusions" {
-  description = "Logging exclusions for this folder in the form {NAME -> FILTER}."
-  type        = map(string)
-  default     = {}
-}
-
-variable "folder_create" {
-  description = "Create folder. When set to false, uses id to reference an existing folder."
-  type        = bool
-  default     = true
-}
-
-variable "id" {
-  description = "Folder ID in case you use folder_create=false"
-  type        = string
-  default     = null
-}
-
-variable "contacts" {
-  description = "List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES"
-  type        = map(list(string))
-  default     = {}
 }

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -13,7 +13,12 @@ This module allows managing several organization properties:
 module "org" {
   source          = "./modules/organization"
   organization_id = "organizations/1234567890"
-  iam             = { "roles/projectCreator" = ["group:cloud-admins@example.org"] }
+  group_iam       = {
+    "cloud-owners@example.org" = ["roles/owner", "roles/projectCreator"]
+  }
+  iam             = {
+    "roles/projectCreator" = ["group:cloud-admins@example.org"]
+  }
   policy_boolean = {
     "constraints/compute.disableGuestAttributesAccess" = true
     "constraints/compute.skipDefaultNetworkCreation"   = true
@@ -27,10 +32,23 @@ module "org" {
     }
   }
 }
-# tftest:modules=1:resources=4
+# tftest:modules=1:resources=5
 ```
 
+## IAM
+
+There are several mutually exclusive ways of managing IAM in this module
+
+- non-authoritative via the `iam_additive` and `iam_additive_members` variables, where bindings created outside this module will coexist with those managed here
+- authoritative via the `group_iam` and `iam` variables, where bindings created outside this module (eg in the console) will be removed at each `terraform apply` cycle if the same role is also managed here
+- authoritative policy via the `iam_bindings_authoritative` variable, where any binding created outside this module (eg in the console) will be removed at each `terraform apply` cycle regardless of the role
+
+Some care must be takend with the `groups_iam` variable (and in some situations with the additive variables) to ensure that variable keys are static values, so that Terraform is able to compute the dependency graph.
+
+
+
 ## Hierarchical firewall rules
+
 ```hcl
 module "org" {
   source          = "./modules/organization"
@@ -60,6 +78,7 @@ module "org" {
 ```
 
 ## Logging Sinks
+
 ```hcl
 module "gcs" {
   source        = "./modules/gcs"
@@ -145,6 +164,7 @@ module "org" {
 | *custom_roles* | Map of role name => list of permissions to create in this project. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *firewall_policies* | Hierarchical firewall policies to *create* in the organization. | <code title="map&#40;map&#40;object&#40;&#123;&#10;description             &#61; string&#10;direction               &#61; string&#10;action                  &#61; string&#10;priority                &#61; number&#10;ranges                  &#61; list&#40;string&#41;&#10;ports                   &#61; map&#40;list&#40;string&#41;&#41;&#10;target_service_accounts &#61; list&#40;string&#41;&#10;target_resources        &#61; list&#40;string&#41;&#10;logging                 &#61; bool&#10;&#125;&#41;&#41;&#41;">map(map(object({...})))</code> |  | <code title="">{}</code> |
 | *firewall_policy_attachments* | List of hierarchical firewall policy IDs to *attach* to the organization | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
+| *group_iam* | Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam* | IAM bindings, in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive* | Non authoritative IAM bindings, in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_members* | IAM additive bindings in {MEMBERS => [ROLE]} format. This might break if members are dynamic values. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -45,8 +45,6 @@ There are several mutually exclusive ways of managing IAM in this module
 
 Some care must be takend with the `groups_iam` variable (and in some situations with the additive variables) to ensure that variable keys are static values, so that Terraform is able to compute the dependency graph.
 
-
-
 ## Hierarchical firewall rules
 
 ```hcl
@@ -153,7 +151,6 @@ module "org" {
 # tftest:modules=5:resources=11
 ```
 
-
 <!-- BEGIN TFDOC -->
 ## Variables
 
@@ -164,7 +161,7 @@ module "org" {
 | *custom_roles* | Map of role name => list of permissions to create in this project. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *firewall_policies* | Hierarchical firewall policies to *create* in the organization. | <code title="map&#40;map&#40;object&#40;&#123;&#10;description             &#61; string&#10;direction               &#61; string&#10;action                  &#61; string&#10;priority                &#61; number&#10;ranges                  &#61; list&#40;string&#41;&#10;ports                   &#61; map&#40;list&#40;string&#41;&#41;&#10;target_service_accounts &#61; list&#40;string&#41;&#10;target_resources        &#61; list&#40;string&#41;&#10;logging                 &#61; bool&#10;&#125;&#41;&#41;&#41;">map(map(object({...})))</code> |  | <code title="">{}</code> |
 | *firewall_policy_attachments* | List of hierarchical firewall policy IDs to *attach* to the organization | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |
-| *group_iam* | Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
+| *group_iam* | Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam* | IAM bindings, in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive* | Non authoritative IAM bindings, in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_members* | IAM additive bindings in {MEMBERS => [ROLE]} format. This might break if members are dynamic values. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -20,6 +20,12 @@ variable "custom_roles" {
   default     = {}
 }
 
+variable "group_iam" {
+  description = "Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "iam" {
   description = "IAM bindings, in {ROLE => [MEMBERS]} format."
   type        = map(list(string))
@@ -49,12 +55,6 @@ variable "iam_audit_config" {
   # }
 }
 
-variable "iam_bindings_authoritative" {
-  description = "IAM authoritative bindings, in {ROLE => [MEMBERS]} format. Roles and members not explicitly listed will be cleared. Bindings should also be authoritative when using authoritative audit config. Use with caution."
-  type        = map(list(string))
-  default     = null
-}
-
 variable "iam_audit_config_authoritative" {
   description = "IAM Authoritative service audit logging configuration. Service as key, map of log permission (eg DATA_READ) and excluded members as value for each service. Audit config should also be authoritative when using authoritative bindings. Use with caution."
   type        = map(map(list(string)))
@@ -64,6 +64,12 @@ variable "iam_audit_config_authoritative" {
   #     DATA_READ = ["user:me@example.org"]
   #   }
   # }
+}
+
+variable "iam_bindings_authoritative" {
+  description = "IAM authoritative bindings, in {ROLE => [MEMBERS]} format. Roles and members not explicitly listed will be cleared. Bindings should also be authoritative when using authoritative audit config. Use with caution."
+  type        = map(list(string))
+  default     = null
 }
 
 variable "organization_id" {

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -21,7 +21,7 @@ variable "custom_roles" {
 }
 
 variable "group_iam" {
-  description = "Atuthoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
+  description = "Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
   type        = map(list(string))
   default     = {}
 }

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -161,7 +161,7 @@ module "project-host" {
 | *contacts* | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *custom_roles* | Map of role name => list of permissions to create in this project. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *group_iam* | Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
-| *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;set&#40;string&#41;&#41;">map(set(string))</code> |  | <code title="">{}</code> |
+| *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive* | IAM additive bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_members* | IAM additive bindings in {MEMBERS => [ROLE]} format. This might break if members are dynamic values. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *labels* | Resource labels. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="">{}</code> |

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -160,6 +160,7 @@ module "project-host" {
 | *billing_account* | Billing account id. | <code title="">string</code> |  | <code title="">null</code> |
 | *contacts* | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *custom_roles* | Map of role name => list of permissions to create in this project. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
+| *group_iam* | Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam* | IAM bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;set&#40;string&#41;&#41;">map(set(string))</code> |  | <code title="">{}</code> |
 | *iam_additive* | IAM additive bindings in {ROLE => [MEMBERS]} format. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |
 | *iam_additive_members* | IAM additive bindings in {MEMBERS => [ROLE]} format. This might break if members are dynamic values. | <code title="map&#40;list&#40;string&#41;&#41;">map(list(string))</code> |  | <code title="">{}</code> |

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -32,9 +32,15 @@ variable "custom_roles" {
   default     = {}
 }
 
+variable "group_iam" {
+  description = "Authoritative IAM binding for organization groups, in {GROUP_EMAIL => [ROLES]} format. Group emails need to be static. Can be used in combination with the `iam` variable."
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "iam" {
   description = "IAM bindings in {ROLE => [MEMBERS]} format."
-  type        = map(set(string))
+  type        = map(list(string))
   default     = {}
 }
 
@@ -196,7 +202,7 @@ variable "contacts" {
 variable "service_perimeter_standard" {
   description = "Name of VPC-SC Standard perimeter to add project into. Specify the name in the form of 'accessPolicies/ACCESS_POLICY_NAME/servicePerimeters/PERIMETER_NAME'."
   type        = string
-  default     = null    
+  default     = null
 }
 
 

--- a/tests/modules/organization/fixture/main.tf
+++ b/tests/modules/organization/fixture/main.tf
@@ -18,6 +18,7 @@ module "test" {
   source                      = "../../../../modules/organization"
   organization_id             = "organizations/1234567890"
   custom_roles                = var.custom_roles
+  group_iam                   = var.group_iam
   iam                         = var.iam
   iam_additive                = var.iam_additive
   iam_additive_members        = var.iam_additive_members

--- a/tests/modules/organization/fixture/variables.tf
+++ b/tests/modules/organization/fixture/variables.tf
@@ -19,6 +19,11 @@ variable "custom_roles" {
   default = {}
 }
 
+variable "group_iam" {
+  type    = map(list(string))
+  default = {}
+}
+
 variable "iam" {
   type    = map(list(string))
   default = {}


### PR DESCRIPTION
This integrates customizations we're making for my current customer, where IAM at the resource hierarchy level is tightly coupled with groups, which are vetted by the security team as a unit, together with their associated roles and point of application (org, folder, project).

Directly supporting this model allows much better readability in the resulting Terraform code, and emphasises the documentation part of IaC, which is one of the core features we aim to support in Fabric.

The feature is implemented via authoritative bindings, as an integral part of the security approval is the assurance that no other bindings are applied outside of this process, but is implemented in a lightweight fashion so that it can be used together with the `iam` variable, to support mixed use-cases or exceptions to the rule. It's of course transparent, so it can be ignored if not needed.

Example usage from the org README:

```hcl
module "org" {
  source          = "./modules/organization"
  organization_id = "organizations/1234567890"
  group_iam       = {
    "cloud-owners@example.org" = ["roles/owner", "roles/projectCreator"]
  }
  iam             = {
    "roles/browser" = ["domain:example.org"]
  }
}
```