### PR TITLE
Make cluster creation optional in Shared VPC example

### DIFF
--- a/networking/shared-vpc-gke/README.md
+++ b/networking/shared-vpc-gke/README.md
@@ -1,4 +1,4 @@
-# Shared VPC with GKE example
+# Shared VPC with optional GKE cluster
 
 This sample creates a basic [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) setup using one host project and two service projects, each with a specific subnet in the shared VPC.
 

--- a/networking/shared-vpc-gke/README.md
+++ b/networking/shared-vpc-gke/README.md
@@ -1,6 +1,10 @@
 # Shared VPC with GKE example
 
-This sample creates a basic [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) setup using one host project and two service projects, each with a specific subnet in the shared VPC. The setup also includes the specific IAM-level configurations needed for [GKE on Shared VPC](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc) to enable cluster creation in one of the two service projects.
+This sample creates a basic [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) setup using one host project and two service projects, each with a specific subnet in the shared VPC.
+
+The setup also includes the specific IAM-level configurations needed for [GKE on Shared VPC](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc) in one of the two service projects, and optionally creates a cluster with a single nodepool.
+
+If you only need a basic Shared VPC, or prefer creating a cluster manually, set the `cluster_create` variable to `False`.
 
 The sample has been purposefully kept simple so that it can be used as a basis for different Shared VPC configurations. This is the high level diagram:
 
@@ -46,6 +50,7 @@ There's a minor glitch that can surface running `terraform destroy`, where the s
 | billing_account_id | Billing account id used as default for new projects. | <code title="">string</code> | ✓ |  |
 | prefix | Prefix used for resources that need unique names. | <code title="">string</code> | ✓ |  |
 | root_node | Hierarchy node where projects will be created, 'organizations/org_id' or 'folders/folder_id'. | <code title="">string</code> | ✓ |  |
+| *cluster_create* | Create GKE cluster and nodepool. | <code title="">bool</code> |  | <code title="">true</code> |
 | *ip_ranges* | Subnet IP CIDR ranges. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="&#123;&#10;gce &#61; &#34;10.0.16.0&#47;24&#34;&#10;gke &#61; &#34;10.0.32.0&#47;24&#34;&#10;&#125;">...</code> |
 | *ip_secondary_ranges* | Secondary IP CIDR ranges. | <code title="map&#40;string&#41;">map(string)</code> |  | <code title="&#123;&#10;gke-pods     &#61; &#34;10.128.0.0&#47;18&#34;&#10;gke-services &#61; &#34;172.16.0.0&#47;24&#34;&#10;&#125;">...</code> |
 | *owners_gce* | GCE project owners, in IAM format. | <code title="list&#40;string&#41;">list(string)</code> |  | <code title="">[]</code> |

--- a/networking/shared-vpc-gke/outputs.tf
+++ b/networking/shared-vpc-gke/outputs.tf
@@ -14,9 +14,11 @@
 
 output "gke_clusters" {
   description = "GKE clusters information."
-  value = {
-    cluster-1 = module.cluster-1.endpoint
-  }
+  value = (
+    var.cluster_create
+    ? { cluster-1 = module.cluster-1.0.endpoint }
+    : {}
+  )
 }
 
 output "projects" {

--- a/networking/shared-vpc-gke/variables.tf
+++ b/networking/shared-vpc-gke/variables.tf
@@ -17,6 +17,30 @@ variable "billing_account_id" {
   type        = string
 }
 
+variable "cluster_create" {
+  description = "Create GKE cluster and nodepool."
+  type        = bool
+  default     = true
+}
+
+variable "ip_ranges" {
+  description = "Subnet IP CIDR ranges."
+  type        = map(string)
+  default = {
+    gce = "10.0.16.0/24"
+    gke = "10.0.32.0/24"
+  }
+}
+
+variable "ip_secondary_ranges" {
+  description = "Secondary IP CIDR ranges."
+  type        = map(string)
+  default = {
+    gke-pods     = "10.128.0.0/18"
+    gke-services = "172.16.0.0/24"
+  }
+}
+
 variable "owners_gce" {
   description = "GCE project owners, in IAM format."
   type        = list(string)
@@ -40,35 +64,6 @@ variable "prefix" {
   type        = string
 }
 
-variable "region" {
-  description = "Region used."
-  type        = string
-  default     = "europe-west1"
-}
-
-variable "root_node" {
-  description = "Hierarchy node where projects will be created, 'organizations/org_id' or 'folders/folder_id'."
-  type        = string
-}
-
-variable "ip_ranges" {
-  description = "Subnet IP CIDR ranges."
-  type        = map(string)
-  default = {
-    gce = "10.0.16.0/24"
-    gke = "10.0.32.0/24"
-  }
-}
-
-variable "ip_secondary_ranges" {
-  description = "Secondary IP CIDR ranges."
-  type        = map(string)
-  default = {
-    gke-pods     = "10.128.0.0/18"
-    gke-services = "172.16.0.0/24"
-  }
-}
-
 variable "private_service_ranges" {
   description = "Private service IP CIDR ranges."
   type        = map(string)
@@ -84,4 +79,15 @@ variable "project_services" {
     "container.googleapis.com",
     "stackdriver.googleapis.com",
   ]
+}
+
+variable "region" {
+  description = "Region used."
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "root_node" {
+  description = "Hierarchy node where projects will be created, 'organizations/org_id' or 'folders/folder_id'."
+  type        = string
 }


### PR DESCRIPTION
This allows quicker creation of the svpc example when a GKE cluster is not needed. I will use this in the upcoming OpenShift example.