### PR TITLE
Update CAI example

### DIFF
--- a/cloud-operations/asset-inventory-feed-remediation/README.md
+++ b/cloud-operations/asset-inventory-feed-remediation/README.md
@@ -33,7 +33,6 @@ Clone this repository or [open it in cloud shell](https://ssh.cloud.google.com/c
 
 - `terraform init`
 - `terraform apply -var project_id=my-project-id`
-- copy and paste the `feed_create` output in the console then run it to create the feed
 
 Once done testing, you can clean up resources by running `terraform destroy`. To persist state, check out the `backend.tf.sample` file.
 
@@ -41,7 +40,6 @@ Once done testing, you can clean up resources by running `terraform destroy`. To
 
 The terraform outputs generate preset `gcloud` commands that you can copy and run in the console, to complete configuration and test the example:
 
-- `feed_create` is run once to create the feed, as there's currently no Terraform resource available for Cloud Asset feeds
 - `subscription_pull` shows messages in the PubSub queue, to check feed message format if the Cloud Function is disabled
 - `cf_logs` shows Cloud Function logs to check that remediation works
 - `tag_add` adds a non-compliant tag to the test instance, and triggers the Cloud Function remediation process
@@ -70,7 +68,6 @@ Run the `subscription_pull` command until it returns nothing, then run the follo
 | name | description | sensitive |
 |---|---|:---:|
 | cf_logs | Cloud Function logs read command. |  |
-| feed_create | Feed gcloud command. |  |
 | subscription_pull | Subscription pull command. |  |
 | tag_add | Instance add tag command. |  |
 | tag_show | Instance add tag command. |  |

--- a/cloud-operations/asset-inventory-feed-remediation/main.tf
+++ b/cloud-operations/asset-inventory-feed-remediation/main.tf
@@ -26,7 +26,8 @@ module "project" {
   services = [
     "cloudasset.googleapis.com",
     "compute.googleapis.com",
-    "cloudfunctions.googleapis.com"
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com"
   ]
   service_config = {
     disable_on_destroy         = false,
@@ -116,4 +117,18 @@ module "simple-vm-example" {
 
 resource "random_pet" "random" {
   length = 1
+}
+
+# Create a feed that sends notifications about instance  updates.
+resource "google_cloud_asset_project_feed" "project_feed" {
+  project      = module.project.project_id
+  feed_id      = var.name
+  content_type = "RESOURCE"
+  asset_types  = ["compute.googleapis.com/Instance"]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = module.pubsub.topic.id
+    }
+  }
 }

--- a/cloud-operations/asset-inventory-feed-remediation/main.tf
+++ b/cloud-operations/asset-inventory-feed-remediation/main.tf
@@ -25,9 +25,9 @@ module "project" {
   project_create = var.project_create
   services = [
     "cloudasset.googleapis.com",
-    "compute.googleapis.com",
+    "cloudbuild.googleapis.com",
     "cloudfunctions.googleapis.com",
-    "cloudbuild.googleapis.com"
+    "compute.googleapis.com"
   ]
   service_config = {
     disable_on_destroy         = false,

--- a/cloud-operations/asset-inventory-feed-remediation/outputs.tf
+++ b/cloud-operations/asset-inventory-feed-remediation/outputs.tf
@@ -26,17 +26,6 @@ gcloud logging read '
   END
 }
 
-output "feed_create" {
-  description = "Feed gcloud command."
-  value       = <<END
-gcloud asset feeds create ${var.name} \
-  --pubsub-topic ${module.pubsub.topic.id} \
-  --asset-types compute.googleapis.com/Instance \
-  --content-type resource \
-  --project ${module.project.project_id}
-  END
-}
-
 output "subscription_pull" {
   description = "Subscription pull command."
   value       = <<END

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -61,7 +61,8 @@ output "service_accounts" {
   }
   depends_on = [
     google_project_service.project_services,
-    google_kms_crypto_key_iam_member.crypto_key
+    google_kms_crypto_key_iam_member.crypto_key,
+    google_project_service_identity.jit_si
   ]
 }
 

--- a/modules/project/service_accounts.tf
+++ b/modules/project/service_accounts.tf
@@ -41,7 +41,8 @@ locals {
   }
   jit_services = [
     "secretmanager.googleapis.com",
-    "pubsub.googleapis.com"
+    "pubsub.googleapis.com",
+    "cloudasset.googleapis.com"
   ]
 }
 

--- a/tests/cloud_operations/asset_inventory_feed_remediation/test_plan.py
+++ b/tests/cloud_operations/asset_inventory_feed_remediation/test_plan.py
@@ -24,4 +24,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner(FIXTURES_DIR)
   assert len(modules) == 6
-  assert len(resources) == 16
+  assert len(resources) == 18

--- a/tests/cloud_operations/scheduled_asset_inventory_export_bq/test_plan.py
+++ b/tests/cloud_operations/scheduled_asset_inventory_export_bq/test_plan.py
@@ -24,4 +24,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner(FIXTURES_DIR)
   assert len(modules) == 5
-  assert len(resources) == 19
+  assert len(resources) == 20

--- a/tests/data_solutions/data_platform_foundations/test_plan.py
+++ b/tests/data_solutions/data_platform_foundations/test_plan.py
@@ -24,4 +24,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner(FIXTURES_DIR)
   assert len(modules) == 6
-  assert len(resources) == 44
+  assert len(resources) == 45


### PR DESCRIPTION
This PR update the CAI remediation example to create the feed directly from terraform instead of gcloud