### PR TITLE
Allow using gVNIC in compute-vm (#211)

### DIFF
--- a/cloud-operations/asset-inventory-feed-remediation/main.tf
+++ b/cloud-operations/asset-inventory-feed-remediation/main.tf
@@ -110,7 +110,6 @@ module "simple-vm-example" {
     subnetwork = try(module.vpc.subnet_self_links["${var.region}/${var.name}-default"], "")
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags = ["${var.project_id}-test-feed", "shared-test-feed"]
 }

--- a/cloud-operations/dns-fine-grained-iam/main.tf
+++ b/cloud-operations/dns-fine-grained-iam/main.tf
@@ -111,7 +111,6 @@ module "vm-ns-editor" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/${var.name}-default"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.startup-script }
   service_account_create = true
@@ -128,7 +127,6 @@ module "vm-svc-editor" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/${var.name}-default"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.startup-script }
   service_account_create = true

--- a/cloud-operations/dns-shared-vpc/examples/shared-vpc-example/test.example
+++ b/cloud-operations/dns-shared-vpc/examples/shared-vpc-example/test.example
@@ -27,7 +27,6 @@ module "vm1" {
     subnetwork = module.shared-vpc.subnet_self_links["${var.region}/subnet-01"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags = ["test-dns"]
 }
@@ -42,7 +41,6 @@ module "vm2" {
     subnetwork = module.shared-vpc.subnet_self_links["${var.region}/subnet-01"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags = ["test-dns"]
 }

--- a/data-solutions/cmek-via-centralized-kms/main.tf
+++ b/data-solutions/cmek-via-centralized-kms/main.tf
@@ -106,7 +106,6 @@ module "vm_example" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/subnet"],
     nat        = false,
     addresses  = null
-    alias_ips  = null
   }]
   attached_disks = [
     {

--- a/data-solutions/gcs-to-bq-with-dataflow/main.tf
+++ b/data-solutions/gcs-to-bq-with-dataflow/main.tf
@@ -206,7 +206,6 @@ module "vm_example" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/${var.vpc_subnet_name}"],
     nat        = false,
     addresses  = null
-    alias_ips  = null
   }]
   attached_disks = [
     {

--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -24,7 +24,6 @@ module "nginx-template" {
     subnetwork = var.subnet.self_link
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"
@@ -71,7 +70,6 @@ module "nginx-template" {
     subnetwork = var.subnet.self_link
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"
@@ -125,7 +123,6 @@ module "nginx-template" {
     subnetwork = var.subnet.self_link,
     nat        = false,
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"
@@ -182,7 +179,6 @@ module "nginx-template" {
     subnetwork = var.subnet.self_link
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"
@@ -235,7 +231,6 @@ module "nginx-template" {
     subnetwork = var.subnet.self_link
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -60,6 +60,13 @@ locals {
       ]
     )
   )
+
+  network_interface_options = {
+    for i, v in var.network_interfaces : i => lookup(var.network_interface_options, i, {
+      alias_ips = null,
+      nic_type  = null
+    })
+  }
 }
 
 resource "google_compute_disk" "disks" {
@@ -193,13 +200,14 @@ resource "google_compute_instance" "default" {
         }
       }
       dynamic "alias_ip_range" {
-        for_each = config.value.alias_ips != null ? config.value.alias_ips : {}
+        for_each = local.network_interface_options[config.key].alias_ips != null ? local.network_interface_options[config.key].alias_ips : {}
         iterator = config_alias
         content {
           subnetwork_range_name = config_alias.key
           ip_cidr_range         = config_alias.value
         }
       }
+      nic_type = local.network_interface_options[config.key].nic_type
     }
   }
 
@@ -318,13 +326,14 @@ resource "google_compute_instance_template" "default" {
         }
       }
       dynamic "alias_ip_range" {
-        for_each = config.value.alias_ips != null ? config.value.alias_ips : {}
+        for_each = local.network_interface_options[config.key].alias_ips != null ? local.network_interface_options[config.key].alias_ips : {}
         iterator = config_alias
         content {
           subnetwork_range_name = config_alias.key
           ip_cidr_range         = config_alias.value
         }
       }
+      nic_type = local.network_interface_options[config.key].nic_type
     }
   }
 

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -162,8 +162,17 @@ variable "name" {
   type        = string
 }
 
+variable "network_interface_options" {
+  description = "Network interfaces extended options. The key is the index of the inteface to configure. The value is an object with alias_ips and nic_type. Set alias_ips or nic_type to null if you need only one of them."
+  type = map(object({
+    alias_ips = map(string)
+    nic_type  = string
+  }))
+  default = {}
+}
+
 variable "network_interfaces" {
-  description = "Network interfaces configuration. Use self links for Shared VPC, set addresses and alias_ips to null if not needed."
+  description = "Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed."
   type = list(object({
     nat        = bool
     network    = string
@@ -172,7 +181,6 @@ variable "network_interfaces" {
       internal = string
       external = string
     })
-    alias_ips = map(string)
   }))
 }
 

--- a/modules/net-ilb/README.md
+++ b/modules/net-ilb/README.md
@@ -72,7 +72,6 @@ module "instance-group" {
     subnetwork = var.subnet.self_link
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "projects/cos-cloud/global/images/family/cos-stable"

--- a/networking/filtering-proxy/main.tf
+++ b/networking/filtering-proxy/main.tf
@@ -158,7 +158,6 @@ module "squid-vm" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/proxy"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "cos-cloud/cos-stable"
@@ -270,7 +269,6 @@ module "test-vm" {
     subnetwork = module.vpc.subnet_self_links["${var.region}/apps"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   boot_disk = {
     image = "debian-cloud/debian-10"

--- a/networking/hub-and-spoke-peering/main.tf
+++ b/networking/hub-and-spoke-peering/main.tf
@@ -182,7 +182,6 @@ module "vm-hub" {
     subnetwork = module.vpc-hub.subnet_self_links["${var.region}/${local.prefix}hub-1"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.vm-startup-script }
   service_account        = module.service-account-gce.email
@@ -200,7 +199,6 @@ module "vm-spoke-1" {
     subnetwork = module.vpc-spoke-1.subnet_self_links["${var.region}/${local.prefix}spoke-1-1"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.vm-startup-script }
   service_account        = module.service-account-gce.email
@@ -218,7 +216,6 @@ module "vm-spoke-2" {
     subnetwork = module.vpc-spoke-2.subnet_self_links["${var.region}/${local.prefix}spoke-2-1"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.vm-startup-script }
   service_account        = module.service-account-gce.email

--- a/networking/hub-and-spoke-vpn/main.tf
+++ b/networking/hub-and-spoke-vpn/main.tf
@@ -250,7 +250,6 @@ module "vm-spoke-1" {
     subnetwork = module.vpc-spoke-1.subnet_self_links["${var.regions.b}/spoke-1-b"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags     = ["ssh"]
   metadata = { startup-script = local.vm-startup-script }
@@ -266,7 +265,6 @@ module "vm-spoke-2" {
     subnetwork = module.vpc-spoke-2.subnet_self_links["${var.regions.b}/spoke-2-b"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags     = ["ssh"]
   metadata = { startup-script = local.vm-startup-script }

--- a/networking/ilb-next-hop/gateways.tf
+++ b/networking/ilb-next-hop/gateways.tf
@@ -33,15 +33,13 @@ module "gw" {
       network    = module.vpc-left.self_link
       subnetwork = values(module.vpc-left.subnet_self_links)[0],
       nat        = false,
-      addresses  = null,
-      alias_ips  = null
+      addresses  = null
     },
     {
       network    = module.vpc-right.self_link
       subnetwork = values(module.vpc-right.subnet_self_links)[0],
       nat        = false,
-      addresses  = null,
-      alias_ips  = null
+      addresses  = null
     }
   ]
   tags           = ["ssh"]

--- a/networking/ilb-next-hop/vms.tf
+++ b/networking/ilb-next-hop/vms.tf
@@ -35,7 +35,6 @@ module "vm-left" {
       subnetwork = values(module.vpc-left.subnet_self_links)[0]
       nat        = false
       addresses  = null
-      alias_ips  = null
     }
   ]
   tags = ["ssh"]
@@ -61,7 +60,6 @@ module "vm-right" {
       subnetwork = values(module.vpc-right.subnet_self_links)[0]
       nat        = false
       addresses  = null
-      alias_ips  = null
     }
   ]
   tags = ["ssh"]

--- a/networking/onprem-google-access-dns/main.tf
+++ b/networking/onprem-google-access-dns/main.tf
@@ -239,7 +239,6 @@ module "vm-test1" {
     subnetwork = module.vpc.subnet_self_links["${var.region.gcp1}/subnet1"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.vm-startup-script }
   service_account        = module.service-account-gce.email
@@ -257,7 +256,6 @@ module "vm-test2" {
     subnetwork = module.vpc.subnet_self_links["${var.region.gcp2}/subnet2"]
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   metadata               = { startup-script = local.vm-startup-script }
   service_account        = module.service-account-gce.email
@@ -325,7 +323,6 @@ module "vm-onprem" {
     subnetwork = module.vpc.subnet_self_links["${var.region.gcp1}/subnet1"]
     nat        = true
     addresses  = null
-    alias_ips  = null
   }]
   service_account        = module.service-account-onprem.email
   service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/networking/private-cloud-function-from-onprem/main.tf
+++ b/networking/private-cloud-function-from-onprem/main.tf
@@ -187,7 +187,6 @@ module "test-vm" {
   }
   network_interfaces = [{
     addresses  = null
-    alias_ips  = null
     nat        = false
     network    = module.vpc-onprem.self_link
     subnetwork = module.vpc-onprem.subnet_self_links["${var.region}/${var.name}-onprem"]

--- a/networking/shared-vpc-gke/main.tf
+++ b/networking/shared-vpc-gke/main.tf
@@ -176,7 +176,6 @@ module "vm-bastion" {
     subnetwork = lookup(module.vpc-shared.subnet_self_links, "${var.region}/gce", null)
     nat        = false
     addresses  = null
-    alias_ips  = null
   }]
   tags = ["ssh"]
   metadata = {

--- a/tests/modules/compute_vm/fixture/variables.tf
+++ b/tests/modules/compute_vm/fixture/variables.tf
@@ -78,15 +78,21 @@ variable "network_interfaces" {
       internal = string
       external = string
     })
-    alias_ips = map(string)
   }))
   default = [{
     network    = "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default",
     subnetwork = "https://www.googleapis.com/compute/v1/projects/my-project/regions/europe-west1/subnetworks/default-default",
     nat        = false,
     addresses  = null
-    alias_ips  = null
   }]
+}
+
+variable "network_interface_options" {
+  type = map(object({
+    alias_ips = map(string)
+    nic_type  = string
+  }))
+  default = {}
 }
 
 variable "service_account_create" {

--- a/tests/modules/compute_vm/test_plan_interfaces.py
+++ b/tests/modules/compute_vm/test_plan_interfaces.py
@@ -26,7 +26,6 @@ def test_address(plan_runner):
     subnetwork = "https://www.googleapis.com/compute/v1/projects/my-project/regions/europe-west1/subnetworks/default-default",
     nat        = false,
     addresses  = {external=null, internal="10.0.0.2"}
-    alias_ips  = null
   }]
   '''
   _, resources = plan_runner(FIXTURES_DIR, network_interfaces=nics)
@@ -42,7 +41,6 @@ def test_nat_address(plan_runner):
     subnetwork = "https://www.googleapis.com/compute/v1/projects/my-project/regions/europe-west1/subnetworks/default-default",
     nat        = true,
     addresses  = {external="8.8.8.8", internal=null}
-    alias_ips  = null
   }]
   '''
   _, resources = plan_runner(FIXTURES_DIR, network_interfaces=nics)

--- a/third-party-solutions/openshift/prepare.py
+++ b/third-party-solutions/openshift/prepare.py
@@ -145,7 +145,7 @@ def ignition_configs(ctx=None):
       'create', 'ignition-configs',
       '--dir', str(ctx.obj['paths']['config_dir'])
   ]
-  env = {'GOOGLE_CREDENTIALS': ctx.obj['paths']['credentials']}
+  env = {'GOOGLE_APPLICATION_CREDENTIALS': ctx.obj['paths']['credentials']}
   _run_installer(cmdline, env)
 
 
@@ -221,7 +221,7 @@ def manifests(ctx=None):
       'create', 'manifests',
       '--dir', str(ctx.obj['paths']['config_dir'])
   ]
-  env = {'GOOGLE_CREDENTIALS': ctx.obj['paths']['credentials']}
+  env = {'GOOGLE_APPLICATION_CREDENTIALS': ctx.obj['paths']['credentials']}
   _run_installer(cmdline, env)
 
 


### PR DESCRIPTION
This only adds the parameter `nic_type` to compute-vm. I would consider creating a module for compute images in order to catch the issue that certain flags are already enabled in public images when enabling `GVNIC` as a guest os feature.