### PR TITLE
Compute service account email statically

### DIFF
--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -56,8 +56,10 @@ locals {
     ? google_service_account_key.key["1"]
     : map("", null)
   , {})
-  prefix             = var.prefix != null ? "${var.prefix}-" : ""
-  resource_iam_email = "serviceAccount:${local.service_account.email}"
+  prefix                    = var.prefix != null ? "${var.prefix}-" : ""
+  resource_email_static     = "${local.prefix}${var.name}@${var.project_id}.iam.gserviceaccount.com"
+  resource_iam_email_static = "serviceAccount:${local.resource_email_static}"
+  resource_iam_email        = "serviceAccount:${local.service_account.email}"
   service_account = (
     var.service_account_create
     ? try(google_service_account.service_account.0, null)

--- a/modules/iam-service-account/outputs.tf
+++ b/modules/iam-service-account/outputs.tf
@@ -21,12 +21,18 @@ output "service_account" {
 
 output "email" {
   description = "Service account email."
-  value       = local.service_account.email
+  value       = local.resource_email_static
+  depends_on = [
+    local.service_account
+  ]
 }
 
 output "iam_email" {
   description = "IAM-format service account email."
-  value       = local.resource_iam_email
+  value       = local.resource_iam_email_static
+  depends_on = [
+    local.service_account
+  ]
 }
 
 output "key" {


### PR DESCRIPTION
Generate the service account output statically based on the service
account name and parent project. This allows, among other things, to use
service accounts as map keys (e.g. to be used in the `iam` argument in
other modules).

With this  PR, the example below works as expected:
```terraform
module "project" {
  source          = "./modules/project"
  billing_account = "XXXX"
  name            = "my-project"
  parent          = "folders/YYYY"
}

module "sa1" {
  source     = "./modules/iam-service-account"
  project_id = module.project.project_id
  name       = "newsa1"
}

module "folder" {
  source = "./modules/folder"
  parent = "folders/ZZZZ"
  name   = "new folder"
  iam = {
    (module.sa1.iam_email) = ["roles/owner"]
  }
}
```