### PR TITLE
Fix SA IAM dynamic interpolation

### DIFF
--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -59,7 +59,7 @@ locals {
   prefix                    = var.prefix != null ? "${var.prefix}-" : ""
   resource_email_static     = "${local.prefix}${var.name}@${var.project_id}.iam.gserviceaccount.com"
   resource_iam_email_static = "serviceAccount:${local.resource_email_static}"
-  resource_iam_email        = "serviceAccount:${local.service_account.email}"
+  resource_iam_email        = local.service_account != null ? "serviceAccount:${local.service_account.email}" : local.resource_iam_email_static
   service_account = (
     var.service_account_create
     ? try(google_service_account.service_account.0, null)


### PR DESCRIPTION
I was getting the following error (on apply only, plans works fine)when trying to create an SA via a module for_each and setting permissions at the same time:
```
│ Error: Attempt to get attribute from null value
│ 
│   on .terraform/modules/projects_tf_infra.sa/modules/iam-service-account/main.tf line 62, in locals:
│   62:   resource_iam_email        = "serviceAccount:${local.service_account.email}"
│     ├────────────────
│     │ local.service_account is null
│ 
│ This value is null, so it does not have any attributes.
```
This fixes it, as it uses the static version of the SA email if local.service_account is null.

However, I don't fully understand why local.service_account is null in this case. Let me know if you'd like to reproduce this locally to look further into this.