### PR TITLE
added depends on topic iam binding

### DIFF
--- a/modules/gcs/main.tf
+++ b/modules/gcs/main.tf
@@ -114,6 +114,9 @@ resource "google_storage_notification" "notification" {
   topic             = google_pubsub_topic.topic[0].id
   event_types       = var.notification_config.event_types
   custom_attributes = var.notification_config.custom_attributes
+
+  depends_on = [google_pubsub_topic_iam_binding.binding]
+
 }
 resource "google_pubsub_topic_iam_binding" "binding" {
   count   = local.notification ? 1 : 0


### PR DESCRIPTION
I've run into scenarios where Terraform attempts to create the gcs notification resource before the topic IAM binding and hence run into 403 issues. I've added an explicit depends on to avoid the scenario.
