### PR TITLE
Added dynamic block for dns_cache_config

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -59,8 +59,11 @@ resource "google_container_cluster" "cluster" {
 
   # TODO(ludomagno): compute addons map in locals and use a single dynamic block
   addons_config {
-    dns_cache_config {
-      enabled = var.addons.dns_cache_config
+    dynamic "dns_cache_config" {
+      for_each = var.enable_autopilot == true ? [] : [""]
+      content {
+        enabled = var.addons.dns_cache_config
+      }
     }
     http_load_balancing {
       disabled = !var.addons.http_load_balancing


### PR DESCRIPTION
It looks like a recent change in the provider added a validation as in the block dns_cache_config when GKE autopilot is enabled: 

```
"dns_cache_config": {
	Type:          schema.TypeList,
	Optional:      true,
	Computed:      true,
	AtLeastOneOf:  addonsConfigKeys,
	MaxItems:      1,
	Description:   `The status of the NodeLocal DNSCache addon. It is disabled by default. Set enabled = true to enable.`,
	**ConflictsWith: []string{"enable_autopilot"},**
```

In order to avoid the validation I've added the dns_cache_config in a dynamic block checking if enable_autopilot is enabled or not.

Thank you!