### PR TITLE
Adding Apigee Environments as output for apigee-organization module

### DIFF
--- a/modules/apigee-organization/README.md
+++ b/modules/apigee-organization/README.md
@@ -118,6 +118,7 @@ module "apigee-organization" {
 
 | name | description | sensitive |
 |---|---|:---:|
+| envs | Apigee Environments. |  |
 | org | Apigee Organization. |  |
 | org_ca_certificate | Apigee organization CA certificate. |  |
 | org_id | Apigee Organization ID. |  |

--- a/modules/apigee-organization/outputs.tf
+++ b/modules/apigee-organization/outputs.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+output "envs" {
+  description = "Apigee Environments."
+  value       = google_apigee_environment.apigee_env
+}
+
 output "org" {
   description = "Apigee Organization."
   value       = google_apigee_organization.apigee_org


### PR DESCRIPTION
Adding `envs` as export to apigee-organization module.

This helps users that want to reference the envs from their apigee-x-instance like so to ensure the instance is created before it is attached.

```hcl
module "apigee-x-instance" {
  source    = "../../../../modules/apigee-x-instance"
  name      = var.name
  region    = var.region
  cidr_mask = 22

  apigee_org_id = "my-project"
  apigee_environments = [
    module.my_org.envs["eval1"].name,
    module.my_org.envs["eval2"].name
  ]
}
```