### PR TITLE
Bump tftest version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def _plan_runner():
     "Runs Terraform plan and returns parsed output."
     tf = tftest.TerraformTest(fixture_path, BASEDIR,
                               os.environ.get('TERRAFORM', 'terraform'))
-    tf.setup()
+    tf.setup(upgrade=True)
     return tf.plan(output=True, refresh=refresh, tf_vars=tf_vars, targets=targets)
 
   return run_plan
@@ -94,7 +94,7 @@ def apply_runner():
     "Runs Terraform apply and returns parsed output"
     tf = tftest.TerraformTest(fixture_path, BASEDIR,
                               os.environ.get('TERRAFORM', 'terraform'))
-    tf.setup()
+    tf.setup(upgrade=True)
     apply = tf.apply(tf_vars=tf_vars)
     output = tf.output(json_format=True)
     return apply, output

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=4.6.0
 PyYAML>=5.3
-tftest>=1.5.2
+tftest>=1.6.1
 marko>=0.9.1


### PR DESCRIPTION
Bump tftest version to 1.6.1 and ensure test runners can update
providers if needed and available.